### PR TITLE
Feat/constructors standings

### DIFF
--- a/src/f1_race_analytics/app.py
+++ b/src/f1_race_analytics/app.py
@@ -18,6 +18,7 @@ from .database import (
     create_race_results,
     create_races,
     get_all_races,
+    get_constructor_ranks,
     get_driver_ranks,
     get_result_by_circuit_id,
     get_session,
@@ -106,5 +107,17 @@ async def get_drivers_standings(
     return templates.TemplateResponse(
         request=request,
         name="drivers_standings.html",
+        context={"standings": standings, "year": YEAR},
+    )
+
+
+@app.get("/standings/constructors", response_class=HTMLResponse)
+async def get_constructors_standings(
+    request: Request, session: Annotated[Session, Depends(get_session)]
+) -> HTMLResponse:
+    standings = get_constructor_ranks(session, YEAR)
+    return templates.TemplateResponse(
+        request=request,
+        name="constructors_standings.html",
         context={"standings": standings, "year": YEAR},
     )

--- a/src/f1_race_analytics/database.py
+++ b/src/f1_race_analytics/database.py
@@ -24,6 +24,11 @@ class DriverStanding(NamedTuple):
     points: int
 
 
+class ConstructorStanding(NamedTuple):
+    constructor: Constructor
+    points: int
+
+
 def create_db_and_tables():
     SQLModel.metadata.create_all(engine)
 
@@ -237,4 +242,41 @@ def get_driver_ranks(session: Session, year: int) -> list[DriverStanding]:
         if driver is None:
             continue
         standings.append(DriverStanding(driver=driver, points=points))
+    return standings
+
+
+def get_constructor_ranks(session: Session, year: int) -> list[ConstructorStanding]:
+    championship = session.exec(
+        select(Championship).where(Championship.year == year)
+    ).first()
+    if championship is None:
+        return []
+
+    race_ids = {race.id for race in championship.races if race.id is not None}
+    results = session.exec(
+        select(RaceResult).where(RaceResult.race_id.in_(race_ids))
+    ).all()
+
+    links = session.exec(
+        select(ChampionshipEntryLink).where(
+            ChampionshipEntryLink.championship_id == championship.id
+        )
+    ).all()
+    driver_to_constructor = {link.driver_id: link.constructor_id for link in links}
+
+    points_by_constructor: dict[int, int] = defaultdict(int)
+    for result in results:
+        if result.driver_id is None:
+            continue
+        constructor_id = driver_to_constructor[result.driver_id]
+        points_by_constructor[constructor_id] += result.points
+
+    standings = []
+    for constructor_id, points in sorted(
+        points_by_constructor.items(), key=lambda x: x[1], reverse=True
+    ):
+        constructor = session.get(Constructor, constructor_id)
+        if constructor is None:
+            continue
+        standings.append(ConstructorStanding(constructor=constructor, points=points))
     return standings

--- a/src/f1_race_analytics/templates/constructors_standings.html
+++ b/src/f1_race_analytics/templates/constructors_standings.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Constructor Standings</title>
+  <link href="https://fonts.googleapis.com/css2?family=Barlow+Condensed:wght@400;600;700;900&family=Barlow:wght@400;500&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="/static/styles.css" />
+</head>
+<body>
+
+  <nav>
+    <div class="nav-logo">F1<span> ·</span></div>
+    <ul class="nav-links">
+      <li><a href="/">Home</a></li>
+    </ul>
+  </nav>
+
+  <header>
+    <p class="season-tag">{{ year }} Season</p>
+    <h1>Constructor <em>Standings</em></h1>
+  </header>
+
+  <section class="races-section">
+    <table style="width:100%; border-collapse: collapse;">
+      <thead>
+        <tr>
+          <th style="text-align:left; padding: .5rem 1rem; color: var(--muted); font-family: 'Barlow Condensed', sans-serif; letter-spacing: 2px; text-transform: uppercase; border-bottom: 1px solid var(--border);">Pos</th>
+          <th style="text-align:left; padding: .5rem 1rem; color: var(--muted); font-family: 'Barlow Condensed', sans-serif; letter-spacing: 2px; text-transform: uppercase; border-bottom: 1px solid var(--border);">Constructor</th>
+          <th style="text-align:left; padding: .5rem 1rem; color: var(--muted); font-family: 'Barlow Condensed', sans-serif; letter-spacing: 2px; text-transform: uppercase; border-bottom: 1px solid var(--border);">Nationality</th>
+          <th style="text-align:left; padding: .5rem 1rem; color: var(--muted); font-family: 'Barlow Condensed', sans-serif; letter-spacing: 2px; text-transform: uppercase; border-bottom: 1px solid var(--border);">Points</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for entry in standings %}
+        <tr {% if loop.index == 1 %}style="color: gold;"
+            {% elif loop.index == 2 %}style="color: silver;"
+            {% elif loop.index == 3 %}style="color: #cd7f32;"{% endif %}>
+          <td style="padding: .5rem 1rem; border-bottom: 1px solid var(--border);">{{ loop.index }}</td>
+          <td style="padding: .5rem 1rem; border-bottom: 1px solid var(--border);">{{ entry.constructor.name }}</td>
+          <td style="padding: .5rem 1rem; border-bottom: 1px solid var(--border);">{{ entry.constructor.nationality }}</td>
+          <td style="padding: .5rem 1rem; border-bottom: 1px solid var(--border);">{{ entry.points }}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </section>
+
+</body>
+</html>

--- a/src/f1_race_analytics/templates/constructors_standings.html
+++ b/src/f1_race_analytics/templates/constructors_standings.html
@@ -13,6 +13,7 @@
     <div class="nav-logo">F1<span> ·</span></div>
     <ul class="nav-links">
       <li><a href="/">Home</a></li>
+      <li><a href="/standings/drivers">Drivers standings</a></li>
     </ul>
   </nav>
 

--- a/src/f1_race_analytics/templates/drivers_standings.html
+++ b/src/f1_race_analytics/templates/drivers_standings.html
@@ -13,6 +13,7 @@
     <div class="nav-logo">F1<span> ·</span></div>
     <ul class="nav-links">
       <li><a href="/">Home</a></li>
+      <li><a href="/standings/constructors">Constructors standings</a></li>
     </ul>
   </nav>
 

--- a/src/f1_race_analytics/templates/index.html
+++ b/src/f1_race_analytics/templates/index.html
@@ -15,6 +15,7 @@
   <div class="nav-logo">F1<span> ·</span></div>
     <ul class="nav-links">
       <li><a href="/standings/drivers">Drivers standings</a></li>
+      <li><a href="/standings/constructors">Constructors standings</a></li>
       {% if replay_url %}
       <li><a href="/replay">Replay session</a></li>
       {% endif %}

--- a/src/f1_race_analytics/tests/test_app.py
+++ b/src/f1_race_analytics/tests/test_app.py
@@ -7,10 +7,12 @@ from f1_race_analytics.database import (
     clear_db_and_tables,
     create_championship,
     create_db_and_tables,
+    create_race_results,
     create_races,
     engine,
+    get_constructor_ranks,
 )
-from f1_race_analytics.f1_data import ConstructorData, DriverData, Event
+from f1_race_analytics.f1_data import ConstructorData, DriverData, Event, ResultData
 from f1_race_analytics.models import (
     Championship,
     ChampionshipEntryLink,
@@ -115,6 +117,60 @@ def constructor_driver_pairs():
                 first_name="Lance",
                 last_name="Stroll",
                 nationality="Canadian",
+            ),
+        ),
+    ]
+
+
+@pytest.fixture
+def standings_pairs():
+    return [
+        (
+            ConstructorData(
+                constructor_id="ferrari", name="Ferrari", nationality="Italian"
+            ),
+            DriverData(
+                driver_id="leclerc",
+                number="16",
+                first_name="Charles",
+                last_name="Leclerc",
+                nationality="Monegasque",
+            ),
+        ),
+        (
+            ConstructorData(
+                constructor_id="ferrari", name="Ferrari", nationality="Italian"
+            ),
+            DriverData(
+                driver_id="hamilton",
+                number="44",
+                first_name="Lewis",
+                last_name="Hamilton",
+                nationality="British",
+            ),
+        ),
+        (
+            ConstructorData(
+                constructor_id="mercedes", name="Mercedes", nationality="German"
+            ),
+            DriverData(
+                driver_id="antonelli",
+                number="12",
+                first_name="Andrea Kimi",
+                last_name="Antonelli",
+                nationality="Italian",
+            ),
+        ),
+        (
+            ConstructorData(
+                constructor_id="mercedes", name="Mercedes", nationality="German"
+            ),
+            DriverData(
+                driver_id="russell",
+                number="63",
+                first_name="George",
+                last_name="Russell",
+                nationality="British",
             ),
         ),
     ]
@@ -377,3 +433,35 @@ def test_championship_entry_link():
         assert len(hamilton.entry_links) == 1
         assert hamilton.entry_links[0].constructor.name == "Mercedes"
         assert hamilton.entry_links[0].championship.year == 2025
+
+
+def test_get_constructor_ranks(race_events, standings_pairs):
+    australian_results = [
+        ResultData("albert_park", "russell", "1", "25"),
+        ResultData("albert_park", "antonelli", "2", "18"),
+        ResultData("albert_park", "leclerc", "3", "15"),
+        ResultData("albert_park", "hamilton", "4", "12"),
+    ]
+    japanese_results = [
+        ResultData("suzuka", "antonelli", "1", "25"),
+        ResultData("suzuka", "leclerc", "3", "15"),
+        ResultData("suzuka", "russell", "4", "12"),
+        ResultData(
+            "suzuka",
+            "hamilton",
+            "6",
+            "8",
+        ),
+    ]
+    create_races(2026, race_events)
+    create_championship(2026, standings_pairs)
+    create_race_results(2026, australian_results)
+    create_race_results(2026, japanese_results)
+
+    with Session(engine) as session:
+        standings = get_constructor_ranks(session, 2026)
+
+        assert [(s.constructor.name, s.points) for s in standings] == [
+            ("Mercedes", 80),
+            ("Ferrari", 50),
+        ]


### PR DESCRIPTION
## Summary

Adds a constructors' championship standings page, mirroring the existing
drivers' standings. Closes #54.

## What's included

- **Query** (`database.py`): new `get_constructor_ranks` + `ConstructorStanding`.
  Maps each driver to their constructor *for the season* via `ChampionshipEntryLink`
  (the 3-way table), sums `RaceResult` points per constructor, and ranks descending.
- **Route** (`app.py`): `GET /standings/constructors` for the current year.
- **Template**: `constructors_standings.html`, mirroring `drivers_standings.html`.
- **Navigation**: homepage link to the new page, plus cross-links between the
  drivers and constructors standings pages.

## Testing

- New `test_get_constructor_ranks`: a two-race championship (Mercedes, Ferrari)
  with known points, asserting both ranking order and per-constructor totals —
  covering aggregation of two drivers per constructor *and* summing across rounds.
- Full suite green; CI runs `pytest` on push/PR.
- Manual check: constructor totals reconcile with the sum of each team's drivers
  on the drivers' standings page.

## Deliberately out of scope

Spotted some test-suite work while here; tracked separately rather than folded in:
- #63 — tidy `test_app.py` (unused block, redundant imports, misspelled/duplicated test)
- #64 — isolate tests from the real database
- #65 — add route/endpoint tests (`app.py` is currently untested)

Styling stays as-is to match the existing pattern; the inline-styles refactor
remains tracked in #55.