### PR TITLE
Replace inline styles with shared .data-table classes

### DIFF
--- a/src/f1_race_analytics/live_api.py
+++ b/src/f1_race_analytics/live_api.py
@@ -30,27 +30,43 @@ def get_race_data_source() -> RaceDataSource:
     return get_data_source()
 
 
+def _row_class(change: int) -> str:
+    if change > 0:
+        return ' class="row-up"'
+    if change < 0:
+        return ' class="row-down"'
+    return ""
+
+
+def _delta_class(cumulative_change: int) -> str:
+    if cumulative_change > 0:
+        return "delta-up"
+    if cumulative_change < 0:
+        return "delta-down"
+    return "delta-flat"
+
+
 def render_positions(positions) -> str:
     rows = "".join(
-        f"<tr style='{'background: rgba(0,255,0,0.08);' if p.change > 0 else 'background: rgba(255,0,0,0.08);' if p.change < 0 else ''}'>"
-        f"<td style='padding: .5rem 1rem; border-bottom: 1px solid var(--border);'>{p.position}</td>"
-        f"<td style='padding: .5rem 1rem; border-bottom: 1px solid var(--border);'>{p.driver_name}</td>"
-        f"<td style='padding: .5rem 1rem; border-bottom: 1px solid var(--border);'>#{p.driver_number}</td>"
-        f"<td style='padding: .5rem 1rem; border-bottom: 1px solid var(--border); color: {'green' if p.cumulative_change > 0 else 'red' if p.cumulative_change < 0 else 'var(--muted)'};'>"
-        f"{'&#9650; +' + str(p.cumulative_change) if p.cumulative_change > 0 else '&#9660; ' + str(p.cumulative_change) if p.cumulative_change < 0 else '&mdash;'}"
-        f"</td>"
-        f"</tr>"
+        f'<tr{_row_class(p.change)}>'
+        f'<td>{p.position}</td>'
+        f'<td>{p.driver_name}</td>'
+        f'<td>#{p.driver_number}</td>'
+        f'<td class="{_delta_class(p.cumulative_change)}">'
+        f'{"&#9650; +" + str(p.cumulative_change) if p.cumulative_change > 0 else "&#9660; " + str(p.cumulative_change) if p.cumulative_change < 0 else "&mdash;"}'
+        f'</td>'
+        f'</tr>'
         for p in positions
     )
-    header_style = "text-align:left; padding: .5rem 1rem; color: var(--muted); font-family: 'Barlow Condensed', sans-serif; letter-spacing: 2px; text-transform: uppercase; border-bottom: 1px solid var(--border);"
+
     return (
         f'<div id="positions">'
-        f"<table style='width:100%; border-collapse: collapse;'>"
+        f'<table class="data-table">'
         f"<thead><tr>"
-        f"<th style='{header_style}'>Pos</th>"
-        f"<th style='{header_style}'>Driver</th>"
-        f"<th style='{header_style}'>No.</th>"
-        f"<th style='{header_style}'>+/-</th>"
+        f"<th>Pos</th>"
+        f"<th>Driver</th>"
+        f"<th>No.</th>"
+        f"<th>+/-</th>"
         f"</tr></thead>"
         f"<tbody>{rows}</tbody>"
         f"</table>"

--- a/src/f1_race_analytics/static/styles.css
+++ b/src/f1_race_analytics/static/styles.css
@@ -192,3 +192,32 @@
       letter-spacing: .3px;
       margin-top: .2rem;
     }
+
+    /* Data tables — standings, race results, live positions */
+    .data-table { width: 100%; border-collapse: collapse; }
+
+    .data-table th,
+    .data-table td {
+      padding: .5rem 1rem;
+      border-bottom: 1px solid var(--border);
+    }
+
+    .data-table th {
+      text-align: left;
+      color: var(--muted);
+      font-family: 'Barlow Condensed', sans-serif;
+      letter-spacing: 2px;
+      text-transform: uppercase;
+    }
+
+    /* Podium rows (top three) */
+    .data-table .pos-1 { color: gold; }
+    .data-table .pos-2 { color: silver; }
+    .data-table .pos-3 { color: #cd7f32; }
+
+    /* Live positions — direction of movement */
+    .data-table .row-up   { background: rgba(0, 255, 0, .08); }
+    .data-table .row-down { background: rgba(255, 0, 0, .08); }
+    .data-table .delta-up   { color: green; }
+    .data-table .delta-down { color: red; }
+    .data-table .delta-flat { color: var(--muted); }

--- a/src/f1_race_analytics/templates/constructors_standings.html
+++ b/src/f1_race_analytics/templates/constructors_standings.html
@@ -23,24 +23,22 @@
   </header>
 
   <section class="races-section">
-    <table style="width:100%; border-collapse: collapse;">
+    <table class="data-table">
       <thead>
         <tr>
-          <th style="text-align:left; padding: .5rem 1rem; color: var(--muted); font-family: 'Barlow Condensed', sans-serif; letter-spacing: 2px; text-transform: uppercase; border-bottom: 1px solid var(--border);">Pos</th>
-          <th style="text-align:left; padding: .5rem 1rem; color: var(--muted); font-family: 'Barlow Condensed', sans-serif; letter-spacing: 2px; text-transform: uppercase; border-bottom: 1px solid var(--border);">Constructor</th>
-          <th style="text-align:left; padding: .5rem 1rem; color: var(--muted); font-family: 'Barlow Condensed', sans-serif; letter-spacing: 2px; text-transform: uppercase; border-bottom: 1px solid var(--border);">Nationality</th>
-          <th style="text-align:left; padding: .5rem 1rem; color: var(--muted); font-family: 'Barlow Condensed', sans-serif; letter-spacing: 2px; text-transform: uppercase; border-bottom: 1px solid var(--border);">Points</th>
+          <th>Pos</th>
+          <th>Constructor</th>
+          <th>Nationality</th>
+          <th>Points</th>
         </tr>
       </thead>
       <tbody>
         {% for entry in standings %}
-        <tr {% if loop.index == 1 %}style="color: gold;"
-            {% elif loop.index == 2 %}style="color: silver;"
-            {% elif loop.index == 3 %}style="color: #cd7f32;"{% endif %}>
-          <td style="padding: .5rem 1rem; border-bottom: 1px solid var(--border);">{{ loop.index }}</td>
-          <td style="padding: .5rem 1rem; border-bottom: 1px solid var(--border);">{{ entry.constructor.name }}</td>
-          <td style="padding: .5rem 1rem; border-bottom: 1px solid var(--border);">{{ entry.constructor.nationality }}</td>
-          <td style="padding: .5rem 1rem; border-bottom: 1px solid var(--border);">{{ entry.points }}</td>
+        <tr{% if loop.index == 1 %} class="pos-1"{% elif loop.index == 2 %} class="pos-2"{% elif loop.index == 3 %} class="pos-3"{% endif %}>
+          <td>{{ loop.index }}</td>
+          <td>{{ entry.constructor.name }}</td>
+          <td>{{ entry.constructor.nationality }}</td>
+          <td>{{ entry.points }}</td>
         </tr>
         {% endfor %}
       </tbody>

--- a/src/f1_race_analytics/templates/drivers_standings.html
+++ b/src/f1_race_analytics/templates/drivers_standings.html
@@ -23,24 +23,22 @@
   </header>
 
   <section class="races-section">
-    <table style="width:100%; border-collapse: collapse;">
+    <table class="data-table">
       <thead>
         <tr>
-          <th style="text-align:left; padding: .5rem 1rem; color: var(--muted); font-family: 'Barlow Condensed', sans-serif; letter-spacing: 2px; text-transform: uppercase; border-bottom: 1px solid var(--border);">Pos</th>
-          <th style="text-align:left; padding: .5rem 1rem; color: var(--muted); font-family: 'Barlow Condensed', sans-serif; letter-spacing: 2px; text-transform: uppercase; border-bottom: 1px solid var(--border);">Driver</th>
-          <th style="text-align:left; padding: .5rem 1rem; color: var(--muted); font-family: 'Barlow Condensed', sans-serif; letter-spacing: 2px; text-transform: uppercase; border-bottom: 1px solid var(--border);">Nationality</th>
-          <th style="text-align:left; padding: .5rem 1rem; color: var(--muted); font-family: 'Barlow Condensed', sans-serif; letter-spacing: 2px; text-transform: uppercase; border-bottom: 1px solid var(--border);">Points</th>
+          <th>Pos</th>
+          <th>Driver</th>
+          <th>Nationality</th>
+          <th>Points</th>
         </tr>
       </thead>
       <tbody>
         {% for entry in standings %}
-        <tr {% if loop.index == 1 %}style="color: gold;"
-            {% elif loop.index == 2 %}style="color: silver;"
-            {% elif loop.index == 3 %}style="color: #cd7f32;"{% endif %}>
-          <td style="padding: .5rem 1rem; border-bottom: 1px solid var(--border);">{{ loop.index }}</td>
-          <td style="padding: .5rem 1rem; border-bottom: 1px solid var(--border);">{{ entry.driver.first_name }} {{ entry.driver.last_name }}</td>
-          <td style="padding: .5rem 1rem; border-bottom: 1px solid var(--border);">{{ entry.driver.nationality }}</td>
-          <td style="padding: .5rem 1rem; border-bottom: 1px solid var(--border);">{{ entry.points }}</td>
+        <tr{% if loop.index == 1 %} class="pos-1"{% elif loop.index == 2 %} class="pos-2"{% elif loop.index == 3 %} class="pos-3"{% endif %}>
+          <td>{{ loop.index }}</td>
+          <td>{{ entry.driver.first_name }} {{ entry.driver.last_name }}</td>
+          <td>{{ entry.driver.nationality }}</td>
+          <td>{{ entry.points }}</td>
         </tr>
         {% endfor %}
       </tbody>

--- a/src/f1_race_analytics/templates/results.html
+++ b/src/f1_race_analytics/templates/results.html
@@ -22,22 +22,20 @@
   </header>
 
   <section class="races-section">
-    <table style="width:100%; border-collapse: collapse;">
+    <table class="data-table">
       <thead>
         <tr>
-          <th style="text-align:left; padding: .5rem 1rem; color: var(--muted); font-family: 'Barlow Condensed', sans-serif; letter-spacing: 2px; text-transform: uppercase; border-bottom: 1px solid var(--border);">Pos</th>
-          <th style="text-align:left; padding: .5rem 1rem; color: var(--muted); font-family: 'Barlow Condensed', sans-serif; letter-spacing: 2px; text-transform: uppercase; border-bottom: 1px solid var(--border);">Driver</th>
-          <th style="text-align:left; padding: .5rem 1rem; color: var(--muted); font-family: 'Barlow Condensed', sans-serif; letter-spacing: 2px; text-transform: uppercase; border-bottom: 1px solid var(--border);">Points</th>
+          <th>Pos</th>
+          <th>Driver</th>
+          <th>Points</th>
         </tr>
       </thead>
       <tbody>
         {% for result in results %}
-        <tr {% if result.position == 1 %}style="color: gold;"
-            {% elif result.position == 2 %}style="color: silver;"
-            {% elif result.position == 3 %}style="color: #cd7f32;"{% endif %}>
-          <td style="padding: .5rem 1rem; border-bottom: 1px solid var(--border);">{{ result.position }}</td>
-          <td style="padding: .5rem 1rem; border-bottom: 1px solid var(--border);">{{ result.driver.first_name }} {{ result.driver.last_name }}</td>
-          <td style="padding: .5rem 1rem; border-bottom: 1px solid var(--border);">{{ result.points }}</td>
+        <tr{% if result.position == 1 %} class="pos-1"{% elif result.position == 2 %} class="pos-2"{% elif result.position == 3 %} class="pos-3"{% endif %}>
+          <td>{{ result.position }}</td>
+          <td>{{ result.driver.first_name }} {{ result.driver.last_name }}</td>
+          <td>{{ result.points }}</td>
         </tr>
         {% endfor %}
       </tbody>


### PR DESCRIPTION
## Summary

Replaces the duplicated inline `style="..."` attributes across the data tables
with a single shared `.data-table` class set. Behavior-preserving — the pages
render identically. Closes #55.

## What changed

- **`static/styles.css`**: new `.data-table` rules — shared `th`/`td` styling,
  podium modifiers (`.pos-1/2/3`), and live-position modifiers
  (`.row-up/down`, `.delta-up/down/flat`).
- **`drivers_standings.html`, `constructors_standings.html`, `results.html`**:
  `<table class="data-table">`, inline cell styles removed, podium coloring moved
  from `style` to `class`. The conditionals are unchanged (standings key off
  `loop.index`, results off `result.position` — deliberately different).
- **`live_api.py::render_positions`**: same swap in the streamed fragment;
  the data-driven row/delta colors now go through two small helpers
  (`_row_class`, `_delta_class`) instead of inline ternaries. Content unchanged.

## Scope note

`constructors_standings.html` was folded into this issue — it didn't exist when
#55 was filed (added in #54) but carried the same inline styles.

## Testing

- `pytest` green. (`render_positions` / the live app remain uncovered by the
  suite — tracked in #65.)
- Manual: standings and results pages render identically; the live replay
  dashboard still tints rows on position swaps and colors the +/- column.