### PR TITLE
Test-suite cleanup: isolate from the real DB, split DB/route tests, add coverage

### DIFF
--- a/src/f1_race_analytics/app.py
+++ b/src/f1_race_analytics/app.py
@@ -17,6 +17,7 @@ from .database import (
     create_db_and_tables,
     create_race_results,
     create_races,
+    engine,
     get_all_races,
     get_constructor_ranks,
     get_driver_ranks,
@@ -39,14 +40,15 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     clear_db_and_tables()
     create_db_and_tables()
     races_data = fetch_races(YEAR)
-    create_races(YEAR, races_data)
     constructor_driver_pairs = fetch_constructor_driver_pairs(YEAR)
-    create_championship(YEAR, constructor_driver_pairs)
-    for race in races_data:
-        if race.status() == EventStatus.PAST:
-            result_data = fetch_results_by_race(YEAR, race.circuit_id)
-            if result_data:
-                create_race_results(YEAR, result_data)
+    with Session(engine) as session:
+        create_races(session, YEAR, races_data)
+        create_championship(session, YEAR, constructor_driver_pairs)
+        for race in races_data:
+            if race.status() == EventStatus.PAST:
+                result_data = fetch_results_by_race(YEAR, race.circuit_id)
+                if result_data:
+                    create_race_results(session, YEAR, result_data)
     yield
 
 
@@ -59,7 +61,8 @@ templates = Jinja2Templates(directory=BASE_DIR / "templates")
 def populate_db():
     create_db_and_tables()
     races_data = fetch_races(YEAR)
-    create_races(YEAR, races_data)
+    with Session(engine) as session:
+        create_races(session, YEAR, races_data)
 
 
 @app.get("/", response_class=HTMLResponse)

--- a/src/f1_race_analytics/database.py
+++ b/src/f1_race_analytics/database.py
@@ -74,7 +74,7 @@ def get_result_by_circuit_id(
     return race_result
 
 
-def get_or_create_championship_by_year(year: int, session: Session) -> Championship:
+def get_or_create_championship_by_year(session: Session, year: int) -> Championship:
     # Check if there is already a Championship instance for "year";
     # otherwise, create one
     statement = select(Championship).where(Championship.year == year)
@@ -87,132 +87,130 @@ def get_or_create_championship_by_year(year: int, session: Session) -> Champions
     return championship
 
 
-def create_races(year: int, races_data: list[Event]) -> Championship:
+def create_races(session: Session, year: int, races_data: list[Event]) -> Championship:
     """
     Create the championship and races instances for the given year
     """
-    with Session(engine) as session:
-        championship = get_or_create_championship_by_year(year, session)
+    championship = get_or_create_championship_by_year(session, year)
+    races = [
+        Race(
+            name=race.name,
+            circuit_id=race.circuit_id,
+            date=race.date,
+            fp1_date=race.fp1_date,
+            circuit_name=race.circuit_name,
+            circuit_locality=race.circuit_locality,
+            circuit_country=race.circuit_country,
+            championship=championship,
+            has_sprint=race.has_sprint,
+        )
+        for race in races_data
+    ]
 
-        races = [
-            Race(
-                name=race.name,
-                circuit_id=race.circuit_id,
-                date=race.date,
-                fp1_date=race.fp1_date,
-                circuit_name=race.circuit_name,
-                circuit_locality=race.circuit_locality,
-                circuit_country=race.circuit_country,
-                championship=championship,
-                has_sprint=race.has_sprint,
-            )
-            for race in races_data
-        ]
-
-        session.add_all(races)
-        session.commit()
-        session.refresh(championship, attribute_names=["year", "races"])
+    session.add_all(races)
+    session.commit()
+    session.refresh(championship, attribute_names=["year", "races"])
     return championship
 
 
 def create_championship(
-    year: int, constructor_driver_pairs: list[tuple[ConstructorData, DriverData]]
+    session: Session,
+    year: int,
+    constructor_driver_pairs: list[tuple[ConstructorData, DriverData]],
 ) -> Championship:
     """
     Create the championship and the linked tables for constructors and their drivers
     """
-    with Session(engine) as session:
-        championship = get_or_create_championship_by_year(year, session)
+    championship = get_or_create_championship_by_year(session, year)
 
-        for constructor_data, driver_data in constructor_driver_pairs:
-            # Look up existing constructor, or create new
-            constructor = session.exec(
-                select(Constructor).where(
-                    Constructor.constructor_id == constructor_data.constructor_id
-                )
-            ).first()
-            if constructor is None:
-                constructor = Constructor(
-                    constructor_id=constructor_data.constructor_id,
-                    name=constructor_data.name,
-                    nationality=constructor_data.nationality,
-                )
-                session.add(constructor)
-            # Look up existing driver, or create new
-            driver = session.exec(
-                select(Driver).where(Driver.driver_id == driver_data.driver_id)
-            ).first()
-            if driver is None:
-                driver = Driver(
-                    driver_id=driver_data.driver_id,
-                    number=driver_data.number,
-                    first_name=driver_data.first_name,
-                    last_name=driver_data.last_name,
-                    nationality=driver_data.nationality,
-                )
-                session.add(driver)
-            session.commit()
+    for constructor_data, driver_data in constructor_driver_pairs:
+        # Look up existing constructor, or create new
+        constructor = session.exec(
+            select(Constructor).where(
+                Constructor.constructor_id == constructor_data.constructor_id
+            )
+        ).first()
+        if constructor is None:
+            constructor = Constructor(
+                constructor_id=constructor_data.constructor_id,
+                name=constructor_data.name,
+                nationality=constructor_data.nationality,
+            )
+            session.add(constructor)
+        # Look up existing driver, or create new
+        driver = session.exec(
+            select(Driver).where(Driver.driver_id == driver_data.driver_id)
+        ).first()
+        if driver is None:
+            driver = Driver(
+                driver_id=driver_data.driver_id,
+                number=driver_data.number,
+                first_name=driver_data.first_name,
+                last_name=driver_data.last_name,
+                nationality=driver_data.nationality,
+            )
+            session.add(driver)
+        session.commit()
 
-            if championship.id is None or constructor.id is None or driver.id is None:
-                raise ValueError(
-                    "Cannot create link: one or more entities have not been saved yet."
-                )
-
-            link = ChampionshipEntryLink(
-                championship_id=championship.id,
-                constructor_id=constructor.id,
-                driver_id=driver.id,
+        if championship.id is None or constructor.id is None or driver.id is None:
+            raise ValueError(
+                "Cannot create link: one or more entities have not been saved yet."
             )
 
-            session.add(link)
-            session.commit()
+        link = ChampionshipEntryLink(
+            championship_id=championship.id,
+            constructor_id=constructor.id,
+            driver_id=driver.id,
+        )
 
-        session.refresh(championship)
+        session.add(link)
+        session.commit()
+
+    session.refresh(championship)
 
     return championship
 
 
 def create_race_results(
-    year: int, race_result_data: list[ResultData]
+    session: Session, year: int, race_result_data: list[ResultData]
 ) -> list[RaceResult] | None:
     """
     Create the RaceResult table, linking results to races for a given year
     """
-    with Session(engine) as session:
-        get_or_create_championship_by_year(year, session)
+    get_or_create_championship_by_year(session, year)
 
-        race_statement = select(Race).where(
-            Race.circuit_id == race_result_data[0].circuit_id
+    race_statement = select(Race).where(
+        Race.circuit_id == race_result_data[0].circuit_id
+    )
+    race = session.exec(race_statement).first()
+    if race is None:
+        return []
+
+    for race_result in race_result_data:
+        # Get the driver by the API's driver_id, that is a string
+        # used inside the API to crossreference the endpoints.
+        driver = session.exec(
+            select(Driver).where(Driver.driver_id == race_result.driver_id)
+        ).first()
+        if driver is None:
+            continue
+        # Use the Driver id primary key (int) as foreign key in the link table
+        try:
+            position = int(race_result.position)
+            points = int(race_result.points)
+        except ValueError:
+            # Skip drivers with non-numeric positions (DSQ, etc.)
+            continue
+        result = RaceResult(
+            race_id=race.id,
+            driver_id=driver.id,
+            position=position,
+            points=points,
         )
-        race = session.exec(race_statement).first()
-        if race is None:
-            return []
+        session.add(result)
 
-        for race_result in race_result_data:
-            # Get the driver by the API's driver_id, that is a string
-            # used inside the API to crossreference the endpoints.
-            driver = session.exec(
-                select(Driver).where(Driver.driver_id == race_result.driver_id)
-            ).first()
-            if driver is None:
-                continue
-            # Use the Driver id primary key (int) as foreign key in the link table
-            try:
-                position = int(race_result.position)
-                points = int(race_result.points)
-            except ValueError:
-                # Skip drivers with non-numeric positions (DSQ, etc.)
-                continue
-            result = RaceResult(
-                race_id=race.id,
-                driver_id=driver.id,
-                position=position,
-                points=points,
-            )
-            session.add(result)
-
-        session.commit()
-        race_results = race.results
+    session.commit()
+    race_results = race.results
     return race_results
 
 

--- a/src/f1_race_analytics/tests/conftest.py
+++ b/src/f1_race_analytics/tests/conftest.py
@@ -1,0 +1,142 @@
+from datetime import date
+
+import pytest
+from sqlalchemy.pool import StaticPool
+from sqlmodel import Session, SQLModel, create_engine
+
+from f1_race_analytics.database import (
+    create_championship,
+    create_race_results,
+    create_races,
+)
+from f1_race_analytics.f1_data import ConstructorData, DriverData, Event, ResultData
+
+
+@pytest.fixture
+def session():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SQLModel.metadata.create_all(engine)
+    with Session(engine) as session:
+        yield session
+    engine.dispose()
+
+
+@pytest.fixture
+def race_events():
+    return [
+        Event(
+            name="Australian Grand Prix",
+            circuit_id="albert_park",
+            date=date(2026, 3, 8),
+            fp1_date=date(2026, 3, 6),
+            circuit_name="Albert Park Grand Prix Circuit",
+            circuit_locality="Melbourne",
+            circuit_country="Australia",
+            has_sprint=False,
+        ),
+        Event(
+            name="Chinese Grand Prix",
+            circuit_id="shanghai",
+            date=date(2026, 3, 15),
+            fp1_date=date(2026, 3, 13),
+            circuit_name="Shanghai International Circuit",
+            circuit_locality="Shanghai",
+            circuit_country="China",
+            has_sprint=True,
+        ),
+        Event(
+            name="Japanese Grand Prix",
+            circuit_id="suzuka",
+            date=date(2026, 3, 29),
+            fp1_date=date(2026, 3, 27),
+            circuit_name="Suzuka Circuit",
+            circuit_locality="Suzuka",
+            circuit_country="Japan",
+            has_sprint=False,
+        ),
+    ]
+
+
+@pytest.fixture
+def standings_pairs():
+    return [
+        (
+            ConstructorData(
+                constructor_id="ferrari", name="Ferrari", nationality="Italian"
+            ),
+            DriverData(
+                driver_id="leclerc",
+                number="16",
+                first_name="Charles",
+                last_name="Leclerc",
+                nationality="Monegasque",
+            ),
+        ),
+        (
+            ConstructorData(
+                constructor_id="ferrari", name="Ferrari", nationality="Italian"
+            ),
+            DriverData(
+                driver_id="hamilton",
+                number="44",
+                first_name="Lewis",
+                last_name="Hamilton",
+                nationality="British",
+            ),
+        ),
+        (
+            ConstructorData(
+                constructor_id="mercedes", name="Mercedes", nationality="German"
+            ),
+            DriverData(
+                driver_id="antonelli",
+                number="12",
+                first_name="Andrea Kimi",
+                last_name="Antonelli",
+                nationality="Italian",
+            ),
+        ),
+        (
+            ConstructorData(
+                constructor_id="mercedes", name="Mercedes", nationality="German"
+            ),
+            DriverData(
+                driver_id="russell",
+                number="63",
+                first_name="George",
+                last_name="Russell",
+                nationality="British",
+            ),
+        ),
+    ]
+
+
+@pytest.fixture
+def seeded_season(session, race_events, standings_pairs):
+    create_races(session, 2026, race_events)
+    create_championship(session, 2026, standings_pairs)
+    create_race_results(
+        session,
+        2026,
+        [
+            ResultData("albert_park", "russell", "1", "25"),
+            ResultData("albert_park", "antonelli", "2", "18"),
+            ResultData("albert_park", "leclerc", "3", "15"),
+            ResultData("albert_park", "hamilton", "4", "12"),
+        ],
+    )
+    create_race_results(
+        session,
+        2026,
+        [
+            ResultData("suzuka", "antonelli", "1", "25"),
+            ResultData("suzuka", "leclerc", "3", "15"),
+            ResultData("suzuka", "russell", "4", "12"),
+            ResultData("suzuka", "hamilton", "6", "8"),
+        ],
+    )
+    return session

--- a/src/f1_race_analytics/tests/test_app.py
+++ b/src/f1_race_analytics/tests/test_app.py
@@ -223,12 +223,6 @@ def test_create_races(race_events):
 def test_create_championship(constructor_driver_pairs):
     create_championship(2026, constructor_driver_pairs)
     with Session(engine) as read_session:
-        all_championships = read_session.exec(select(Championship)).all()
-        all_links = read_session.exec(select(ChampionshipEntryLink)).all()
-        print("Championships:", all_championships)
-        print("Links:", all_links)
-
-    with Session(engine) as read_session:
         championship = read_session.exec(
             select(Championship).where(Championship.year == 2026)
         ).first()
@@ -243,6 +237,7 @@ def test_create_championship(constructor_driver_pairs):
         pairs = [(link.constructor, link.driver) for link in links]
 
         assert championship.year == 2026
+        # constructors are deduped, so a team keeps one id (Aston is 2, not 3)
         assert pairs == [
             (
                 Constructor(
@@ -311,39 +306,6 @@ def test_create_championship(constructor_driver_pairs):
         ]
 
 
-def test_contructor_drivers_association(constructor_driver_pairs):
-    create_championship(2026, constructor_driver_pairs)
-    with Session(engine) as read_session:
-        championship = read_session.exec(
-            select(Championship).where(Championship.year == 2026)
-        ).first()
-
-        assert championship is not None
-
-        links = read_session.exec(
-            select(ChampionshipEntryLink).where(
-                ChampionshipEntryLink.championship_id == championship.id
-            )
-        ).all()
-        pairs = [(link.constructor, link.driver) for link in links]
-        assert pairs[2] == (
-            Constructor(
-                nationality="British",
-                constructor_id="aston_martin",
-                name="Aston Martin",
-                id=2,
-            ),  # not 3
-            Driver(
-                driver_id="alonso",
-                last_name="Alonso",
-                id=3,
-                number="14",
-                first_name="Fernando",
-                nationality="Spanish",
-            ),
-        )
-
-
 def test_championship_entry_link():
     """
     Test the 3-way link table (ChampionshipEntryLink) that connects
@@ -351,10 +313,6 @@ def test_championship_entry_link():
     This pattern allows us to model: "Driver X drove for Constructor Y
     in Championship Z" - a many-to-many-to-many relationship.
     """
-    from sqlmodel import Session
-
-    from f1_race_analytics.database import engine
-    from f1_race_analytics.models import Championship
 
     with Session(engine) as session:
         # Step 1: Create the parent entities independently

--- a/src/f1_race_analytics/tests/test_app.py
+++ b/src/f1_race_analytics/tests/test_app.py
@@ -1,421 +1,54 @@
-from datetime import date
-
 import pytest
-from sqlmodel import Session, SQLModel, create_engine, select
+from fastapi.testclient import TestClient
 
-from f1_race_analytics.database import (
-    create_championship,
-    create_race_results,
-    create_races,
-    get_constructor_ranks,
-)
-from f1_race_analytics.f1_data import ConstructorData, DriverData, Event, ResultData
-from f1_race_analytics.models import (
-    Championship,
-    ChampionshipEntryLink,
-    Constructor,
-    Driver,
-    Race,
-)
+from f1_race_analytics.app import app
+from f1_race_analytics.database import create_races, get_session
 
 
 @pytest.fixture
-def session():
-    engine = create_engine("sqlite://")
-    SQLModel.metadata.create_all(engine)
-    with Session(engine) as session:
-        yield session
-    engine.dispose()
+def client(session):
+    def get_session_override():
+        return session
+
+    app.dependency_overrides[get_session] = get_session_override
+    client = TestClient(app)
+    yield client
+    app.dependency_overrides.clear()
 
 
-@pytest.fixture
-def race_events():
-    return [
-        Event(
-            name="Australian Grand Prix",
-            circuit_id="albert_park",
-            date=date(2026, 3, 8),
-            fp1_date=date(2026, 3, 6),
-            circuit_name="Albert Park Grand Prix Circuit",
-            circuit_locality="Melbourne",
-            circuit_country="Australia",
-            has_sprint=False,
-        ),
-        Event(
-            name="Chinese Grand Prix",
-            circuit_id="shanghai",
-            date=date(2026, 3, 15),
-            fp1_date=date(2026, 3, 13),
-            circuit_name="Shanghai International Circuit",
-            circuit_locality="Shanghai",
-            circuit_country="China",
-            has_sprint=True,
-        ),
-        Event(
-            name="Japanese Grand Prix",
-            circuit_id="suzuka",
-            date=date(2026, 3, 29),
-            fp1_date=date(2026, 3, 27),
-            circuit_name="Suzuka Circuit",
-            circuit_locality="Suzuka",
-            circuit_country="Japan",
-            has_sprint=False,
-        ),
-    ]
+def test_replay_404_when_url_unset(client, monkeypatch):
+    monkeypatch.setattr("f1_race_analytics.app.REPLAY_URL", None)
+
+    response = client.get("/replay")
+
+    assert response.status_code == 404
 
 
-@pytest.fixture
-def constructor_driver_pairs():
-    return [
-        (
-            ConstructorData(
-                constructor_id="alpine", name="Alpine F1 Team", nationality="French"
-            ),
-            DriverData(
-                driver_id="colapinto",
-                number="43",
-                first_name="Franco",
-                last_name="Colapinto",
-                nationality="Argentine",
-            ),
-        ),
-        (
-            ConstructorData(
-                constructor_id="alpine", name="Alpine F1 Team", nationality="French"
-            ),
-            DriverData(
-                driver_id="gasly",
-                number="10",
-                first_name="Pierre",
-                last_name="Gasly",
-                nationality="French",
-            ),
-        ),
-        (
-            ConstructorData(
-                constructor_id="aston_martin",
-                name="Aston Martin",
-                nationality="British",
-            ),
-            DriverData(
-                driver_id="alonso",
-                number="14",
-                first_name="Fernando",
-                last_name="Alonso",
-                nationality="Spanish",
-            ),
-        ),
-        (
-            ConstructorData(
-                constructor_id="aston_martin",
-                name="Aston Martin",
-                nationality="British",
-            ),
-            DriverData(
-                driver_id="stroll",
-                number="18",
-                first_name="Lance",
-                last_name="Stroll",
-                nationality="Canadian",
-            ),
-        ),
-    ]
-
-
-@pytest.fixture
-def standings_pairs():
-    return [
-        (
-            ConstructorData(
-                constructor_id="ferrari", name="Ferrari", nationality="Italian"
-            ),
-            DriverData(
-                driver_id="leclerc",
-                number="16",
-                first_name="Charles",
-                last_name="Leclerc",
-                nationality="Monegasque",
-            ),
-        ),
-        (
-            ConstructorData(
-                constructor_id="ferrari", name="Ferrari", nationality="Italian"
-            ),
-            DriverData(
-                driver_id="hamilton",
-                number="44",
-                first_name="Lewis",
-                last_name="Hamilton",
-                nationality="British",
-            ),
-        ),
-        (
-            ConstructorData(
-                constructor_id="mercedes", name="Mercedes", nationality="German"
-            ),
-            DriverData(
-                driver_id="antonelli",
-                number="12",
-                first_name="Andrea Kimi",
-                last_name="Antonelli",
-                nationality="Italian",
-            ),
-        ),
-        (
-            ConstructorData(
-                constructor_id="mercedes", name="Mercedes", nationality="German"
-            ),
-            DriverData(
-                driver_id="russell",
-                number="63",
-                first_name="George",
-                last_name="Russell",
-                nationality="British",
-            ),
-        ),
-    ]
-
-
-def test_create_races(session, race_events):
-    championship = create_races(session, 2026, race_events)
-    assert championship.id == 1
-    assert championship.year == 2026
-    assert championship.races == [
-        Race(
-            id=1,
-            name="Australian Grand Prix",
-            circuit_id="albert_park",
-            date=date(2026, 3, 8),
-            fp1_date=date(2026, 3, 6),
-            circuit_name="Albert Park Grand Prix Circuit",
-            circuit_locality="Melbourne",
-            circuit_country="Australia",
-            has_sprint=False,
-            championship_id=1,
-        ),
-        Race(
-            id=2,
-            name="Chinese Grand Prix",
-            circuit_id="shanghai",
-            date=date(2026, 3, 15),
-            fp1_date=date(2026, 3, 13),
-            circuit_name="Shanghai International Circuit",
-            circuit_locality="Shanghai",
-            circuit_country="China",
-            has_sprint=True,
-            championship_id=1,
-        ),
-        Race(
-            id=3,
-            name="Japanese Grand Prix",
-            circuit_id="suzuka",
-            date=date(2026, 3, 29),
-            fp1_date=date(2026, 3, 27),
-            circuit_name="Suzuka Circuit",
-            circuit_locality="Suzuka",
-            circuit_country="Japan",
-            has_sprint=False,
-            championship_id=1,
-        ),
-    ]
-
-
-def test_create_championship(session, constructor_driver_pairs):
-    create_championship(session, 2026, constructor_driver_pairs)
-    championship = session.exec(
-        select(Championship).where(Championship.year == 2026)
-    ).first()
-
-    assert championship is not None
-
-    links = session.exec(
-        select(ChampionshipEntryLink).where(
-            ChampionshipEntryLink.championship_id == championship.id
-        )
-    ).all()
-    pairs = [(link.constructor, link.driver) for link in links]
-
-    assert championship.year == 2026
-    # constructors are deduped, so a team keeps one id (Aston is 2, not 3)
-    assert pairs == [
-        (
-            Constructor(
-                nationality="French",
-                constructor_id="alpine",
-                name="Alpine F1 Team",
-                id=1,
-            ),
-            Driver(
-                driver_id="colapinto",
-                last_name="Colapinto",
-                id=1,
-                number="43",
-                first_name="Franco",
-                nationality="Argentine",
-            ),
-        ),
-        (
-            Constructor(
-                nationality="French",
-                constructor_id="alpine",
-                name="Alpine F1 Team",
-                id=1,
-            ),
-            Driver(
-                driver_id="gasly",
-                last_name="Gasly",
-                id=2,
-                number="10",
-                first_name="Pierre",
-                nationality="French",
-            ),
-        ),
-        (
-            Constructor(
-                nationality="British",
-                constructor_id="aston_martin",
-                name="Aston Martin",
-                id=2,
-            ),
-            Driver(
-                driver_id="alonso",
-                last_name="Alonso",
-                id=3,
-                number="14",
-                first_name="Fernando",
-                nationality="Spanish",
-            ),
-        ),
-        (
-            Constructor(
-                nationality="British",
-                constructor_id="aston_martin",
-                name="Aston Martin",
-                id=2,
-            ),
-            Driver(
-                driver_id="stroll",
-                last_name="Stroll",
-                id=4,
-                number="18",
-                first_name="Lance",
-                nationality="Canadian",
-            ),
-        ),
-    ]
-
-
-def test_championship_entry_link(session):
-    """
-    Test the 3-way link table (ChampionshipEntryLink) that connects
-    Championship, Constructor, and Driver.
-    This pattern allows us to model: "Driver X drove for Constructor Y
-    in Championship Z" - a many-to-many-to-many relationship.
-    """
-
-    championship = Championship(year=2025)
-    session.add(championship)
-    session.commit()
-    session.refresh(championship)
-
-    ferrari = Constructor(
-        constructor_id="ferrari", name="Ferrari", nationality="Italian"
-    )
-    mercedes = Constructor(
-        constructor_id="mercedes", name="Mercedes", nationality="German"
-    )
-    session.add_all([ferrari, mercedes])
-    session.commit()
-    session.refresh(ferrari)
-    session.refresh(mercedes)
-
-    leclerc = Driver(
-        driver_id="leclerc",
-        number="16",
-        first_name="Charles",
-        last_name="Leclerc",
-        nationality="Monegasque",
-    )
-    hamilton = Driver(
-        driver_id="hamilton",
-        number="44",
-        first_name="Lewis",
-        last_name="Hamilton",
-        nationality="British",
-    )
-    session.add_all([leclerc, hamilton])
-    session.commit()
-    session.refresh(leclerc)
-    session.refresh(hamilton)
-
-    # Step 2: Create the link entries using the IDs from the parent entities
-    # Each link represents: "This driver drove for this constructor in this championship"
-
-    # Ensure all entities were persisted before creating links
-    assert championship.id is not None
-    assert ferrari.id is not None
-    assert leclerc.id is not None
-
-    link1 = ChampionshipEntryLink(
-        championship_id=championship.id,
-        constructor_id=ferrari.id,
-        driver_id=leclerc.id,
-    )
-
-    assert championship.id is not None
-    assert mercedes.id is not None
-    assert hamilton.id is not None
-
-    link2 = ChampionshipEntryLink(
-        championship_id=championship.id,
-        constructor_id=mercedes.id,
-        driver_id=hamilton.id,
-    )
-    session.add_all([link1, link2])
-    session.commit()
-
-    # Step 3: Verify navigation from Championship -> entries
-    session.refresh(championship)
-    assert len(championship.entry_links) == 2
-
-    # Step 4: Verify navigation from Constructor -> entries -> Driver
-    session.refresh(ferrari)
-    assert len(ferrari.entry_links) == 1
-    assert ferrari.entry_links[0].driver.last_name == "Leclerc"
-
-    # Step 5: Verify navigation from Driver -> entries -> Constructor and Championship
-    session.refresh(hamilton)
-    assert len(hamilton.entry_links) == 1
-    assert hamilton.entry_links[0].constructor.name == "Mercedes"
-    assert hamilton.entry_links[0].championship.year == 2025
-
-
-def test_get_constructor_ranks(session, race_events, standings_pairs):
-    australian_results = [
-        ResultData("albert_park", "russell", "1", "25"),
-        ResultData("albert_park", "antonelli", "2", "18"),
-        ResultData("albert_park", "leclerc", "3", "15"),
-        ResultData("albert_park", "hamilton", "4", "12"),
-    ]
-    japanese_results = [
-        ResultData("suzuka", "antonelli", "1", "25"),
-        ResultData("suzuka", "leclerc", "3", "15"),
-        ResultData("suzuka", "russell", "4", "12"),
-        ResultData(
-            "suzuka",
-            "hamilton",
-            "6",
-            "8",
-        ),
-    ]
+def test_index_lists_races(client, session, race_events):
     create_races(session, 2026, race_events)
-    create_championship(session, 2026, standings_pairs)
-    create_race_results(session, 2026, australian_results)
-    create_race_results(session, 2026, japanese_results)
 
-    standings = get_constructor_ranks(session, 2026)
+    response = client.get("/")
 
-    assert [(s.constructor.name, s.points) for s in standings] == [
-        ("Mercedes", 80),
-        ("Ferrari", 50),
-    ]
+    assert response.status_code == 200
+    assert "Melbourne" in response.text
+
+
+def test_drivers_standings(client, seeded_season):
+    response = client.get("/standings/drivers")
+
+    assert response.status_code == 200
+    assert "Antonelli" in response.text
+
+
+def test_constructors_standings(client, seeded_season):
+    response = client.get("/standings/constructors")
+
+    assert response.status_code == 200
+    assert "Mercedes" in response.text
+
+
+def test_race_results(client, seeded_season):
+    response = client.get("/results/albert_park")
+
+    assert response.status_code == 200
+    assert "Russell" in response.text

--- a/src/f1_race_analytics/tests/test_app.py
+++ b/src/f1_race_analytics/tests/test_app.py
@@ -1,15 +1,12 @@
 from datetime import date
 
 import pytest
-from sqlmodel import Session, select
+from sqlmodel import Session, SQLModel, create_engine, select
 
 from f1_race_analytics.database import (
-    clear_db_and_tables,
     create_championship,
-    create_db_and_tables,
     create_race_results,
     create_races,
-    engine,
     get_constructor_ranks,
 )
 from f1_race_analytics.f1_data import ConstructorData, DriverData, Event, ResultData
@@ -22,10 +19,13 @@ from f1_race_analytics.models import (
 )
 
 
-@pytest.fixture(autouse=True)
-def setup_database():
-    clear_db_and_tables()
-    create_db_and_tables()
+@pytest.fixture
+def session():
+    engine = create_engine("sqlite://")
+    SQLModel.metadata.create_all(engine)
+    with Session(engine) as session:
+        yield session
+    engine.dispose()
 
 
 @pytest.fixture
@@ -176,8 +176,8 @@ def standings_pairs():
     ]
 
 
-def test_create_races(race_events):
-    championship = create_races(2026, race_events)
+def test_create_races(session, race_events):
+    championship = create_races(session, 2026, race_events)
     assert championship.id == 1
     assert championship.year == 2026
     assert championship.races == [
@@ -220,93 +220,92 @@ def test_create_races(race_events):
     ]
 
 
-def test_create_championship(constructor_driver_pairs):
-    create_championship(2026, constructor_driver_pairs)
-    with Session(engine) as read_session:
-        championship = read_session.exec(
-            select(Championship).where(Championship.year == 2026)
-        ).first()
+def test_create_championship(session, constructor_driver_pairs):
+    create_championship(session, 2026, constructor_driver_pairs)
+    championship = session.exec(
+        select(Championship).where(Championship.year == 2026)
+    ).first()
 
-        assert championship is not None
+    assert championship is not None
 
-        links = read_session.exec(
-            select(ChampionshipEntryLink).where(
-                ChampionshipEntryLink.championship_id == championship.id
-            )
-        ).all()
-        pairs = [(link.constructor, link.driver) for link in links]
+    links = session.exec(
+        select(ChampionshipEntryLink).where(
+            ChampionshipEntryLink.championship_id == championship.id
+        )
+    ).all()
+    pairs = [(link.constructor, link.driver) for link in links]
 
-        assert championship.year == 2026
-        # constructors are deduped, so a team keeps one id (Aston is 2, not 3)
-        assert pairs == [
-            (
-                Constructor(
-                    nationality="French",
-                    constructor_id="alpine",
-                    name="Alpine F1 Team",
-                    id=1,
-                ),
-                Driver(
-                    driver_id="colapinto",
-                    last_name="Colapinto",
-                    id=1,
-                    number="43",
-                    first_name="Franco",
-                    nationality="Argentine",
-                ),
+    assert championship.year == 2026
+    # constructors are deduped, so a team keeps one id (Aston is 2, not 3)
+    assert pairs == [
+        (
+            Constructor(
+                nationality="French",
+                constructor_id="alpine",
+                name="Alpine F1 Team",
+                id=1,
             ),
-            (
-                Constructor(
-                    nationality="French",
-                    constructor_id="alpine",
-                    name="Alpine F1 Team",
-                    id=1,
-                ),
-                Driver(
-                    driver_id="gasly",
-                    last_name="Gasly",
-                    id=2,
-                    number="10",
-                    first_name="Pierre",
-                    nationality="French",
-                ),
+            Driver(
+                driver_id="colapinto",
+                last_name="Colapinto",
+                id=1,
+                number="43",
+                first_name="Franco",
+                nationality="Argentine",
             ),
-            (
-                Constructor(
-                    nationality="British",
-                    constructor_id="aston_martin",
-                    name="Aston Martin",
-                    id=2,
-                ),
-                Driver(
-                    driver_id="alonso",
-                    last_name="Alonso",
-                    id=3,
-                    number="14",
-                    first_name="Fernando",
-                    nationality="Spanish",
-                ),
+        ),
+        (
+            Constructor(
+                nationality="French",
+                constructor_id="alpine",
+                name="Alpine F1 Team",
+                id=1,
             ),
-            (
-                Constructor(
-                    nationality="British",
-                    constructor_id="aston_martin",
-                    name="Aston Martin",
-                    id=2,
-                ),
-                Driver(
-                    driver_id="stroll",
-                    last_name="Stroll",
-                    id=4,
-                    number="18",
-                    first_name="Lance",
-                    nationality="Canadian",
-                ),
+            Driver(
+                driver_id="gasly",
+                last_name="Gasly",
+                id=2,
+                number="10",
+                first_name="Pierre",
+                nationality="French",
             ),
-        ]
+        ),
+        (
+            Constructor(
+                nationality="British",
+                constructor_id="aston_martin",
+                name="Aston Martin",
+                id=2,
+            ),
+            Driver(
+                driver_id="alonso",
+                last_name="Alonso",
+                id=3,
+                number="14",
+                first_name="Fernando",
+                nationality="Spanish",
+            ),
+        ),
+        (
+            Constructor(
+                nationality="British",
+                constructor_id="aston_martin",
+                name="Aston Martin",
+                id=2,
+            ),
+            Driver(
+                driver_id="stroll",
+                last_name="Stroll",
+                id=4,
+                number="18",
+                first_name="Lance",
+                nationality="Canadian",
+            ),
+        ),
+    ]
 
 
-def test_championship_entry_link():
+def test_championship_entry_link(session):
     """
     Test the 3-way link table (ChampionshipEntryLink) that connects
     Championship, Constructor, and Driver.
@@ -314,86 +313,84 @@ def test_championship_entry_link():
     in Championship Z" - a many-to-many-to-many relationship.
     """
 
-    with Session(engine) as session:
-        # Step 1: Create the parent entities independently
-        championship = Championship(year=2025)
-        session.add(championship)
-        session.commit()
-        session.refresh(championship)
+    championship = Championship(year=2025)
+    session.add(championship)
+    session.commit()
+    session.refresh(championship)
 
-        ferrari = Constructor(
-            constructor_id="ferrari", name="Ferrari", nationality="Italian"
-        )
-        mercedes = Constructor(
-            constructor_id="mercedes", name="Mercedes", nationality="German"
-        )
-        session.add_all([ferrari, mercedes])
-        session.commit()
-        session.refresh(ferrari)
-        session.refresh(mercedes)
+    ferrari = Constructor(
+        constructor_id="ferrari", name="Ferrari", nationality="Italian"
+    )
+    mercedes = Constructor(
+        constructor_id="mercedes", name="Mercedes", nationality="German"
+    )
+    session.add_all([ferrari, mercedes])
+    session.commit()
+    session.refresh(ferrari)
+    session.refresh(mercedes)
 
-        leclerc = Driver(
-            driver_id="leclerc",
-            number="16",
-            first_name="Charles",
-            last_name="Leclerc",
-            nationality="Monegasque",
-        )
-        hamilton = Driver(
-            driver_id="hamilton",
-            number="44",
-            first_name="Lewis",
-            last_name="Hamilton",
-            nationality="British",
-        )
-        session.add_all([leclerc, hamilton])
-        session.commit()
-        session.refresh(leclerc)
-        session.refresh(hamilton)
+    leclerc = Driver(
+        driver_id="leclerc",
+        number="16",
+        first_name="Charles",
+        last_name="Leclerc",
+        nationality="Monegasque",
+    )
+    hamilton = Driver(
+        driver_id="hamilton",
+        number="44",
+        first_name="Lewis",
+        last_name="Hamilton",
+        nationality="British",
+    )
+    session.add_all([leclerc, hamilton])
+    session.commit()
+    session.refresh(leclerc)
+    session.refresh(hamilton)
 
-        # Step 2: Create the link entries using the IDs from the parent entities
-        # Each link represents: "This driver drove for this constructor in this championship"
+    # Step 2: Create the link entries using the IDs from the parent entities
+    # Each link represents: "This driver drove for this constructor in this championship"
 
-        # Ensure all entities were persisted before creating links
-        assert championship.id is not None
-        assert ferrari.id is not None
-        assert leclerc.id is not None
+    # Ensure all entities were persisted before creating links
+    assert championship.id is not None
+    assert ferrari.id is not None
+    assert leclerc.id is not None
 
-        link1 = ChampionshipEntryLink(
-            championship_id=championship.id,
-            constructor_id=ferrari.id,
-            driver_id=leclerc.id,
-        )
+    link1 = ChampionshipEntryLink(
+        championship_id=championship.id,
+        constructor_id=ferrari.id,
+        driver_id=leclerc.id,
+    )
 
-        assert championship.id is not None
-        assert mercedes.id is not None
-        assert hamilton.id is not None
+    assert championship.id is not None
+    assert mercedes.id is not None
+    assert hamilton.id is not None
 
-        link2 = ChampionshipEntryLink(
-            championship_id=championship.id,
-            constructor_id=mercedes.id,
-            driver_id=hamilton.id,
-        )
-        session.add_all([link1, link2])
-        session.commit()
+    link2 = ChampionshipEntryLink(
+        championship_id=championship.id,
+        constructor_id=mercedes.id,
+        driver_id=hamilton.id,
+    )
+    session.add_all([link1, link2])
+    session.commit()
 
-        # Step 3: Verify navigation from Championship -> entries
-        session.refresh(championship)
-        assert len(championship.entry_links) == 2
+    # Step 3: Verify navigation from Championship -> entries
+    session.refresh(championship)
+    assert len(championship.entry_links) == 2
 
-        # Step 4: Verify navigation from Constructor -> entries -> Driver
-        session.refresh(ferrari)
-        assert len(ferrari.entry_links) == 1
-        assert ferrari.entry_links[0].driver.last_name == "Leclerc"
+    # Step 4: Verify navigation from Constructor -> entries -> Driver
+    session.refresh(ferrari)
+    assert len(ferrari.entry_links) == 1
+    assert ferrari.entry_links[0].driver.last_name == "Leclerc"
 
-        # Step 5: Verify navigation from Driver -> entries -> Constructor and Championship
-        session.refresh(hamilton)
-        assert len(hamilton.entry_links) == 1
-        assert hamilton.entry_links[0].constructor.name == "Mercedes"
-        assert hamilton.entry_links[0].championship.year == 2025
+    # Step 5: Verify navigation from Driver -> entries -> Constructor and Championship
+    session.refresh(hamilton)
+    assert len(hamilton.entry_links) == 1
+    assert hamilton.entry_links[0].constructor.name == "Mercedes"
+    assert hamilton.entry_links[0].championship.year == 2025
 
 
-def test_get_constructor_ranks(race_events, standings_pairs):
+def test_get_constructor_ranks(session, race_events, standings_pairs):
     australian_results = [
         ResultData("albert_park", "russell", "1", "25"),
         ResultData("albert_park", "antonelli", "2", "18"),
@@ -411,15 +408,14 @@ def test_get_constructor_ranks(race_events, standings_pairs):
             "8",
         ),
     ]
-    create_races(2026, race_events)
-    create_championship(2026, standings_pairs)
-    create_race_results(2026, australian_results)
-    create_race_results(2026, japanese_results)
+    create_races(session, 2026, race_events)
+    create_championship(session, 2026, standings_pairs)
+    create_race_results(session, 2026, australian_results)
+    create_race_results(session, 2026, japanese_results)
 
-    with Session(engine) as session:
-        standings = get_constructor_ranks(session, 2026)
+    standings = get_constructor_ranks(session, 2026)
 
-        assert [(s.constructor.name, s.points) for s in standings] == [
-            ("Mercedes", 80),
-            ("Ferrari", 50),
-        ]
+    assert [(s.constructor.name, s.points) for s in standings] == [
+        ("Mercedes", 80),
+        ("Ferrari", 50),
+    ]

--- a/src/f1_race_analytics/tests/test_database.py
+++ b/src/f1_race_analytics/tests/test_database.py
@@ -78,6 +78,32 @@ def constructor_driver_pairs():
     ]
 
 
+@pytest.fixture
+def seeded_standings(session, race_events, standings_pairs):
+    """Seed two races of results; the rank tests' expected points are computed from this data."""
+    australian_results = [
+        ResultData("albert_park", "russell", "1", "25"),
+        ResultData("albert_park", "antonelli", "2", "18"),
+        ResultData("albert_park", "leclerc", "3", "15"),
+        ResultData("albert_park", "hamilton", "4", "12"),
+    ]
+    japanese_results = [
+        ResultData("suzuka", "antonelli", "1", "25"),
+        ResultData("suzuka", "leclerc", "3", "15"),
+        ResultData("suzuka", "russell", "4", "12"),
+        ResultData(
+            "suzuka",
+            "hamilton",
+            "6",
+            "8",
+        ),
+    ]
+    create_races(session, 2026, race_events)
+    create_championship(session, 2026, standings_pairs)
+    create_race_results(session, 2026, australian_results)
+    create_race_results(session, 2026, japanese_results)
+
+
 def test_create_races(session, race_events):
     championship = create_races(session, 2026, race_events)
     assert championship.id == 1
@@ -293,29 +319,7 @@ def test_championship_entry_link(session):
     assert hamilton.entry_links[0].championship.year == 2025
 
 
-def test_get_constructor_ranks(session, race_events, standings_pairs):
-    australian_results = [
-        ResultData("albert_park", "russell", "1", "25"),
-        ResultData("albert_park", "antonelli", "2", "18"),
-        ResultData("albert_park", "leclerc", "3", "15"),
-        ResultData("albert_park", "hamilton", "4", "12"),
-    ]
-    japanese_results = [
-        ResultData("suzuka", "antonelli", "1", "25"),
-        ResultData("suzuka", "leclerc", "3", "15"),
-        ResultData("suzuka", "russell", "4", "12"),
-        ResultData(
-            "suzuka",
-            "hamilton",
-            "6",
-            "8",
-        ),
-    ]
-    create_races(session, 2026, race_events)
-    create_championship(session, 2026, standings_pairs)
-    create_race_results(session, 2026, australian_results)
-    create_race_results(session, 2026, japanese_results)
-
+def test_get_constructor_ranks(session, seeded_standings):
     standings = get_constructor_ranks(session, 2026)
 
     assert [(s.constructor.name, s.points) for s in standings] == [
@@ -324,29 +328,7 @@ def test_get_constructor_ranks(session, race_events, standings_pairs):
     ]
 
 
-def test_get_driver_ranks(session, race_events, standings_pairs):
-    australian_results = [
-        ResultData("albert_park", "russell", "1", "25"),
-        ResultData("albert_park", "antonelli", "2", "18"),
-        ResultData("albert_park", "leclerc", "3", "15"),
-        ResultData("albert_park", "hamilton", "4", "12"),
-    ]
-    japanese_results = [
-        ResultData("suzuka", "antonelli", "1", "25"),
-        ResultData("suzuka", "leclerc", "3", "15"),
-        ResultData("suzuka", "russell", "4", "12"),
-        ResultData(
-            "suzuka",
-            "hamilton",
-            "6",
-            "8",
-        ),
-    ]
-    create_races(session, 2026, race_events)
-    create_championship(session, 2026, standings_pairs)
-    create_race_results(session, 2026, australian_results)
-    create_race_results(session, 2026, japanese_results)
-
+def test_get_driver_ranks(session, seeded_standings):
     standings = get_driver_ranks(session, 2026)
 
     assert [(s.driver.last_name, s.points) for s in standings] == [

--- a/src/f1_race_analytics/tests/test_database.py
+++ b/src/f1_race_analytics/tests/test_database.py
@@ -8,6 +8,7 @@ from f1_race_analytics.database import (
     create_race_results,
     create_races,
     get_constructor_ranks,
+    get_driver_ranks,
 )
 from f1_race_analytics.f1_data import ConstructorData, DriverData, ResultData
 from f1_race_analytics.models import (
@@ -320,4 +321,37 @@ def test_get_constructor_ranks(session, race_events, standings_pairs):
     assert [(s.constructor.name, s.points) for s in standings] == [
         ("Mercedes", 80),
         ("Ferrari", 50),
+    ]
+
+
+def test_get_driver_ranks(session, race_events, standings_pairs):
+    australian_results = [
+        ResultData("albert_park", "russell", "1", "25"),
+        ResultData("albert_park", "antonelli", "2", "18"),
+        ResultData("albert_park", "leclerc", "3", "15"),
+        ResultData("albert_park", "hamilton", "4", "12"),
+    ]
+    japanese_results = [
+        ResultData("suzuka", "antonelli", "1", "25"),
+        ResultData("suzuka", "leclerc", "3", "15"),
+        ResultData("suzuka", "russell", "4", "12"),
+        ResultData(
+            "suzuka",
+            "hamilton",
+            "6",
+            "8",
+        ),
+    ]
+    create_races(session, 2026, race_events)
+    create_championship(session, 2026, standings_pairs)
+    create_race_results(session, 2026, australian_results)
+    create_race_results(session, 2026, japanese_results)
+
+    standings = get_driver_ranks(session, 2026)
+
+    assert [(s.driver.last_name, s.points) for s in standings] == [
+        ("Antonelli", 43),
+        ("Russell", 37),
+        ("Leclerc", 30),
+        ("Hamilton", 20),
     ]

--- a/src/f1_race_analytics/tests/test_database.py
+++ b/src/f1_race_analytics/tests/test_database.py
@@ -1,0 +1,323 @@
+from datetime import date
+
+import pytest
+from sqlmodel import select
+
+from f1_race_analytics.database import (
+    create_championship,
+    create_race_results,
+    create_races,
+    get_constructor_ranks,
+)
+from f1_race_analytics.f1_data import ConstructorData, DriverData, ResultData
+from f1_race_analytics.models import (
+    Championship,
+    ChampionshipEntryLink,
+    Constructor,
+    Driver,
+    Race,
+)
+
+
+@pytest.fixture
+def constructor_driver_pairs():
+    return [
+        (
+            ConstructorData(
+                constructor_id="alpine", name="Alpine F1 Team", nationality="French"
+            ),
+            DriverData(
+                driver_id="colapinto",
+                number="43",
+                first_name="Franco",
+                last_name="Colapinto",
+                nationality="Argentine",
+            ),
+        ),
+        (
+            ConstructorData(
+                constructor_id="alpine", name="Alpine F1 Team", nationality="French"
+            ),
+            DriverData(
+                driver_id="gasly",
+                number="10",
+                first_name="Pierre",
+                last_name="Gasly",
+                nationality="French",
+            ),
+        ),
+        (
+            ConstructorData(
+                constructor_id="aston_martin",
+                name="Aston Martin",
+                nationality="British",
+            ),
+            DriverData(
+                driver_id="alonso",
+                number="14",
+                first_name="Fernando",
+                last_name="Alonso",
+                nationality="Spanish",
+            ),
+        ),
+        (
+            ConstructorData(
+                constructor_id="aston_martin",
+                name="Aston Martin",
+                nationality="British",
+            ),
+            DriverData(
+                driver_id="stroll",
+                number="18",
+                first_name="Lance",
+                last_name="Stroll",
+                nationality="Canadian",
+            ),
+        ),
+    ]
+
+
+def test_create_races(session, race_events):
+    championship = create_races(session, 2026, race_events)
+    assert championship.id == 1
+    assert championship.year == 2026
+    assert championship.races == [
+        Race(
+            id=1,
+            name="Australian Grand Prix",
+            circuit_id="albert_park",
+            date=date(2026, 3, 8),
+            fp1_date=date(2026, 3, 6),
+            circuit_name="Albert Park Grand Prix Circuit",
+            circuit_locality="Melbourne",
+            circuit_country="Australia",
+            has_sprint=False,
+            championship_id=1,
+        ),
+        Race(
+            id=2,
+            name="Chinese Grand Prix",
+            circuit_id="shanghai",
+            date=date(2026, 3, 15),
+            fp1_date=date(2026, 3, 13),
+            circuit_name="Shanghai International Circuit",
+            circuit_locality="Shanghai",
+            circuit_country="China",
+            has_sprint=True,
+            championship_id=1,
+        ),
+        Race(
+            id=3,
+            name="Japanese Grand Prix",
+            circuit_id="suzuka",
+            date=date(2026, 3, 29),
+            fp1_date=date(2026, 3, 27),
+            circuit_name="Suzuka Circuit",
+            circuit_locality="Suzuka",
+            circuit_country="Japan",
+            has_sprint=False,
+            championship_id=1,
+        ),
+    ]
+
+
+def test_create_championship(session, constructor_driver_pairs):
+    create_championship(session, 2026, constructor_driver_pairs)
+    championship = session.exec(
+        select(Championship).where(Championship.year == 2026)
+    ).first()
+
+    assert championship is not None
+
+    links = session.exec(
+        select(ChampionshipEntryLink).where(
+            ChampionshipEntryLink.championship_id == championship.id
+        )
+    ).all()
+    pairs = [(link.constructor, link.driver) for link in links]
+
+    assert championship.year == 2026
+    # constructors are deduped, so a team keeps one id (Aston is 2, not 3)
+    assert pairs == [
+        (
+            Constructor(
+                nationality="French",
+                constructor_id="alpine",
+                name="Alpine F1 Team",
+                id=1,
+            ),
+            Driver(
+                driver_id="colapinto",
+                last_name="Colapinto",
+                id=1,
+                number="43",
+                first_name="Franco",
+                nationality="Argentine",
+            ),
+        ),
+        (
+            Constructor(
+                nationality="French",
+                constructor_id="alpine",
+                name="Alpine F1 Team",
+                id=1,
+            ),
+            Driver(
+                driver_id="gasly",
+                last_name="Gasly",
+                id=2,
+                number="10",
+                first_name="Pierre",
+                nationality="French",
+            ),
+        ),
+        (
+            Constructor(
+                nationality="British",
+                constructor_id="aston_martin",
+                name="Aston Martin",
+                id=2,
+            ),
+            Driver(
+                driver_id="alonso",
+                last_name="Alonso",
+                id=3,
+                number="14",
+                first_name="Fernando",
+                nationality="Spanish",
+            ),
+        ),
+        (
+            Constructor(
+                nationality="British",
+                constructor_id="aston_martin",
+                name="Aston Martin",
+                id=2,
+            ),
+            Driver(
+                driver_id="stroll",
+                last_name="Stroll",
+                id=4,
+                number="18",
+                first_name="Lance",
+                nationality="Canadian",
+            ),
+        ),
+    ]
+
+
+def test_championship_entry_link(session):
+    """
+    Test the 3-way link table (ChampionshipEntryLink) that connects
+    Championship, Constructor, and Driver.
+    This pattern allows us to model: "Driver X drove for Constructor Y
+    in Championship Z" - a many-to-many-to-many relationship.
+    """
+
+    # Built by hand instead of via create_championship: this test targets the ORM
+    # relationships (the entry_links navigation below), so staying off the mutator
+    # keeps it independent — a failure here points at the model wiring, not
+    # create_championship.
+    championship = Championship(year=2025)
+    session.add(championship)
+    session.commit()
+    session.refresh(championship)
+
+    ferrari = Constructor(
+        constructor_id="ferrari", name="Ferrari", nationality="Italian"
+    )
+    mercedes = Constructor(
+        constructor_id="mercedes", name="Mercedes", nationality="German"
+    )
+    session.add_all([ferrari, mercedes])
+    session.commit()
+    session.refresh(ferrari)
+    session.refresh(mercedes)
+
+    leclerc = Driver(
+        driver_id="leclerc",
+        number="16",
+        first_name="Charles",
+        last_name="Leclerc",
+        nationality="Monegasque",
+    )
+    hamilton = Driver(
+        driver_id="hamilton",
+        number="44",
+        first_name="Lewis",
+        last_name="Hamilton",
+        nationality="British",
+    )
+    session.add_all([leclerc, hamilton])
+    session.commit()
+    session.refresh(leclerc)
+    session.refresh(hamilton)
+
+    # Ensure all entities were persisted before creating links
+    assert championship.id is not None
+    assert ferrari.id is not None
+    assert leclerc.id is not None
+
+    link1 = ChampionshipEntryLink(
+        championship_id=championship.id,
+        constructor_id=ferrari.id,
+        driver_id=leclerc.id,
+    )
+
+    assert championship.id is not None
+    assert mercedes.id is not None
+    assert hamilton.id is not None
+
+    link2 = ChampionshipEntryLink(
+        championship_id=championship.id,
+        constructor_id=mercedes.id,
+        driver_id=hamilton.id,
+    )
+    session.add_all([link1, link2])
+    session.commit()
+
+    # Verify navigation from Championship -> entries
+    session.refresh(championship)
+    assert len(championship.entry_links) == 2
+
+    # Verify navigation from Constructor -> entries -> Driver
+    session.refresh(ferrari)
+    assert len(ferrari.entry_links) == 1
+    assert ferrari.entry_links[0].driver.last_name == "Leclerc"
+
+    # Verify navigation from Driver -> entries -> Constructor and Championship
+    session.refresh(hamilton)
+    assert len(hamilton.entry_links) == 1
+    assert hamilton.entry_links[0].constructor.name == "Mercedes"
+    assert hamilton.entry_links[0].championship.year == 2025
+
+
+def test_get_constructor_ranks(session, race_events, standings_pairs):
+    australian_results = [
+        ResultData("albert_park", "russell", "1", "25"),
+        ResultData("albert_park", "antonelli", "2", "18"),
+        ResultData("albert_park", "leclerc", "3", "15"),
+        ResultData("albert_park", "hamilton", "4", "12"),
+    ]
+    japanese_results = [
+        ResultData("suzuka", "antonelli", "1", "25"),
+        ResultData("suzuka", "leclerc", "3", "15"),
+        ResultData("suzuka", "russell", "4", "12"),
+        ResultData(
+            "suzuka",
+            "hamilton",
+            "6",
+            "8",
+        ),
+    ]
+    create_races(session, 2026, race_events)
+    create_championship(session, 2026, standings_pairs)
+    create_race_results(session, 2026, australian_results)
+    create_race_results(session, 2026, japanese_results)
+
+    standings = get_constructor_ranks(session, 2026)
+
+    assert [(s.constructor.name, s.points) for s in standings] == [
+        ("Mercedes", 80),
+        ("Ferrari", 50),
+    ]


### PR DESCRIPTION
## What this does

Cleans up and hardens the test suite and isolates it from the real database.
Three threads, one branch:

### #63 — tidy the DB tests

Removed redundant local imports and a dead debug block, and dropped a duplicate
test that was a strict subset of `test_create_championship` (its dedup intent is
kept as a one-line comment).

### #64 + #23 — isolate tests from the real DB

The `create_*` mutators (and `get_or_create_championship_by_year`) now take an
injected `session` instead of opening their own `Session(engine)`. Production
callers — the app lifespan and `populate_db` — open one session and pass it
down. Tests run against a per-test in-memory SQLite database via a `session`
fixture; create → yield → teardown is automatic, since the in-memory DB
evaporates when the connection closes. This replaces the old autouse fixture
that rebuilt the real `database.db`. Confirmed a `pytest` run no longer touches
`database.db`.

### #65 — route tests + file split

- Split the suite: `test_database.py` holds the DB-layer tests, a fresh
  `test_app.py` holds the FastAPI route tests, and `conftest.py` holds the
  shared fixtures (`session`, `race_events`, `standings_pairs`, `seeded_season`).
- Added route tests for `/`, `/standings/drivers`, `/standings/constructors`,
  `/results/{circuit_id}`, and `/replay`'s 404, driving the app through
  `TestClient` with `get_session` overridden onto the test session and the
  lifespan left dormant (no network calls, no real-DB rebuild).
- Added `test_get_driver_ranks` so driver standings are pinned directly, not
  only smoke-tested through the route.
- Extracted the shared race-results seeding into a `seeded_standings` fixture
  used by both rank tests.

## Result

- 9 → 10 tests, all green.
- Coverage: `app.py` 0% → 70%, `database.py` up to 86%.
- The suite no longer reads or writes the real `database.db`.

## Deferred

#29 (encapsulate the engine / move data access into a class) is intentionally
**not** in this PR. #64's session injection already resolved #29's
test-isolation motivation; the remaining engine-encapsulation piece is tracked
for a follow-up that introduces a `DataStore` class. Filing it separately keeps
this PR focused on the test suite.

Closes #63
Closes #64
Closes #65
Closes #23