### PR TITLE
test: pin app.YEAR in route tests and harden standings assertions

### DIFF
--- a/src/f1_race_analytics/tests/conftest.py
+++ b/src/f1_race_analytics/tests/conftest.py
@@ -4,6 +4,7 @@ import pytest
 from sqlalchemy.pool import StaticPool
 from sqlmodel import Session, SQLModel, create_engine
 
+import f1_race_analytics.app as app
 from f1_race_analytics.database import (
     create_championship,
     create_race_results,
@@ -116,12 +117,20 @@ def standings_pairs():
 
 
 @pytest.fixture
-def seeded_season(session, race_events, standings_pairs):
-    create_races(session, 2026, race_events)
-    create_championship(session, 2026, standings_pairs)
+def seeded_season(session, race_events, standings_pairs, monkeypatch):
+    # Deliberately NOT the current calendar year: this makes the app.YEAR pin
+    # below load-bearing. It locks down app.YEAR to a fixed value, instead of
+    # letting it be whatever "datetime.now().year" returns.
+    # Remove the monkeypatch and the year falls back to the value returned by
+    # "datetime.now().year", but without 2099 data. So standings route tests
+    # would go red now, instead of silently passing until the clock catches up.
+    year = 2099
+    monkeypatch.setattr(app, "YEAR", year)
+    create_races(session, year, race_events)
+    create_championship(session, year, standings_pairs)
     create_race_results(
         session,
-        2026,
+        year,
         [
             ResultData("albert_park", "russell", "1", "25"),
             ResultData("albert_park", "antonelli", "2", "18"),
@@ -131,7 +140,7 @@ def seeded_season(session, race_events, standings_pairs):
     )
     create_race_results(
         session,
-        2026,
+        year,
         [
             ResultData("suzuka", "antonelli", "1", "25"),
             ResultData("suzuka", "leclerc", "3", "15"),

--- a/src/f1_race_analytics/tests/test_app.py
+++ b/src/f1_race_analytics/tests/test_app.py
@@ -37,14 +37,20 @@ def test_drivers_standings(client, seeded_season):
     response = client.get("/standings/drivers")
 
     assert response.status_code == 200
-    assert "Antonelli" in response.text
+    body = response.text
+    order = ["Antonelli", "Russell", "Leclerc", "Hamilton"]
+    positions = [body.index(name) for name in order]
+    assert positions == sorted(positions)
 
 
 def test_constructors_standings(client, seeded_season):
     response = client.get("/standings/constructors")
 
     assert response.status_code == 200
-    assert "Mercedes" in response.text
+    body = response.text
+    order = ["Mercedes", "Ferrari"]
+    positions = [body.index(name) for name in order]
+    assert positions == sorted(positions)
 
 
 def test_race_results(client, seeded_season):


### PR DESCRIPTION
## What

Removes the standings route tests' dependency on the system clock, and tightens
their assertions at the same time. Test-only — no production changes.

## Why

The `/standings/*` routes filter by `app.YEAR` (`datetime.now().year`, fixed at
import). The route tests passed only because the seeded season happened to match
the current calendar year — on Jan 1 they'd query a year with no seeded data,
render empty standings, and fail with no code change. A calendar-triggered
failure (#71).

## Changes

- **Pin `app.YEAR` in `seeded_season`** via `monkeypatch`, so the routes always
  query the year the fixture seeds. The seeded year is deliberately *non-current*
  (2099), which makes the pin load-bearing: remove the `monkeypatch` line and the
  standings tests go red immediately, instead of silently passing until the clock
  catches up.
- **Strengthen the standings assertions** from "a name appears" to "names render
  in points order" (`positions == sorted(positions)`). The old check tolerated
  wrong ordering; the new one pins that the route computes and renders sorted
  standings, without asserting brittle point values from the HTML.

## Verification

- Full suite green (10 passed).
- Commenting out the `monkeypatch` line turns `test_drivers_standings` and
  `test_constructors_standings` red, confirming the pin is load-bearing.

Closes #71