### PR TITLE
chore: remove unused get_race_by_circuit_id

### DIFF
--- a/src/f1_race_analytics/database.py
+++ b/src/f1_race_analytics/database.py
@@ -51,12 +51,6 @@ def get_all_races(session: Session) -> Sequence[Race]:
     return races
 
 
-def get_race_by_circuit_id(session: Session, circuit_id: str) -> Race | None:
-    statement = select(Race).where(Race.circuit_id == circuit_id)
-    race = session.exec(statement).first()
-    return race
-
-
 def get_result_by_circuit_id(
     session: Session, circuit_id: str
 ) -> Sequence[RaceResult] | None:


### PR DESCRIPTION
**Removes the unused `get_race_by_circuit_id` from `database.py`** — defined, never called since the pivot to Jinja2.

**Why:** it was the first stab at clickable future-race cards, but the detail flow shipped differently (past races → `/results/{circuit_id}`, future races stay inactive), so it never got wired up. Nothing imports, calls, or tests it, and `select` is still used across the other queries. Future intent lives in #74; recoverable from git if ever pursued.

**Also closes #28** — its week-3 checklist is done or superseded:
- Done: circuit fields on `Race`, `get_all_races()`, table creation moved into the lifespan.
- Superseded: the pure-JSON `/races` + `/races/{circuit_id}` endpoints and the NiceGUI prototype → went with server-rendered Jinja2 (`/`, `/results/{circuit_id}`).
- Standalone periodic populate stays in #22.

Closes #28