### PR TITLE
fix: return 404 when race not found by circuit_id

### DIFF
--- a/src/f1_race_analytics/app.py
+++ b/src/f1_race_analytics/app.py
@@ -82,6 +82,8 @@ async def get_race_result(
     circuit_id: str, request: Request, session: Annotated[Session, Depends(get_session)]
 ) -> HTMLResponse:
     results = get_result_by_circuit_id(session, circuit_id)
+    if results is None:
+        raise HTTPException(status_code=404, detail="Race not found")
     return templates.TemplateResponse(
         request=request,
         name="results.html",

--- a/src/f1_race_analytics/database.py
+++ b/src/f1_race_analytics/database.py
@@ -62,6 +62,7 @@ def get_result_by_circuit_id(
         select(RaceResult)
         .where(RaceResult.race_id == race.id)
         .order_by(RaceResult.position)
+        # eager-load each result's driver up front, else the template fires one query per row (N+1)
         .options(selectinload(RaceResult.driver))
     )
     race_result = session.exec(saved_result).all()

--- a/src/f1_race_analytics/tests/test_app.py
+++ b/src/f1_race_analytics/tests/test_app.py
@@ -58,3 +58,21 @@ def test_race_results(client, seeded_season):
 
     assert response.status_code == 200
     assert "Russell" in response.text
+
+
+def test_results_unknown_circuit_returns_404(client, seeded_season):
+    response = client.get("/results/rome")
+
+    assert response.status_code == 404
+
+
+def test_circuit_with_no_results_returns_200(client, seeded_season):
+    # `seeded_season` takes `race_events` as an argument and passes it straight
+    # to `create_races`, that creates all 3 events, including Shanghai.
+    # But `seeded_season` only calls `create_race_results` for `albert_park`
+    # and `suzuka`, so `shanghai` exists as a race but it has zero results.
+    # This guards the `is None` check: if it's ever "simplified" to `if not results`,
+    # shanghai's [] would wrongly 404 and this test goes red.
+    response = client.get("/results/shanghai")
+
+    assert response.status_code == 200


### PR DESCRIPTION
**What this does:** `/results/{circuit_id}` now returns a proper 404 for a circuit that doesn't exist, instead of a 500.

**Why:** an unknown circuit_id made `get_result_by_circuit_id` return `None`, which the route passed straight to the template — and `{% for result in results %}` over `None` raised `TypeError: 'NoneType' object is not iterable`, surfacing as a 500. The route now checks for `None` and raises `HTTPException(404, "Race not found")`.

**The `None`-vs-`[]` distinction (deliberate):** the check is `if results is None`, not `if not results`. A circuit with no matching race → `None` → 404. A real race that simply has no results yet (future or unpopulated) → `[]` → still renders (200). `is None` keeps those apart; `not results` would wrongly 404 the empty-but-real case.

**Tests:**
- `test_results_unknown_circuit_returns_404` — unknown circuit → 404 (this was a 500 before the fix, so the test is red without it).
- `test_circuit_with_no_results_returns_200` — `shanghai`, a seeded race with no results, → 200; guards the `is None` choice against being changed to `not results`.

Also includes a one-line comment on the `selectinload` in `get_result_by_circuit_id` explaining the N+1 avoidance (separate `docs:` commit).

Closes #31