### PR TITLE
refactor: build Jolpica URLs from path segments

### DIFF
--- a/src/f1_race_analytics/f1_data.py
+++ b/src/f1_race_analytics/f1_data.py
@@ -185,17 +185,18 @@ def _build_url(year: int, *segments: str) -> str:
     return url
 
 
-def _fetch_data(year: int, endpoint: str) -> dict[str, dict] | None:
+def _fetch_data(year: int, *segments: str) -> dict[str, dict] | None:
     """
     Retrieve historical data from Jolpica F1 API:
     """
+    url = _build_url(year, *segments)
     try:
-        response = httpx.get(f"{JOLPICA_ENDPOINT}/{year}/{endpoint}/")
+        response = httpx.get(url)
         response.raise_for_status()
         return response.json()
     except httpx.HTTPStatusError as e:
         print(
-            f"Failed to fetch data for {endpoint} for season {year}: {e.response.status_code}"
+            f"Failed to fetch data for {url} for season {year}: {e.response.status_code}"
         )
         return None
     except httpx.RequestError as e:

--- a/src/f1_race_analytics/f1_data.py
+++ b/src/f1_race_analytics/f1_data.py
@@ -130,7 +130,7 @@ def fetch_constructor_driver_pairs(
 
 
 def fetch_drivers_by_constructor(year: int, constructor_id: str) -> list[DriverData]:
-    drivers_data = _fetch_data(year, f"/constructors/{constructor_id}/drivers/")
+    drivers_data = _fetch_data(year, "constructors", constructor_id, "drivers")
     if drivers_data is None:
         print("Sorry, something went wrong")
         return []
@@ -149,7 +149,7 @@ def fetch_drivers_by_constructor(year: int, constructor_id: str) -> list[DriverD
 
 
 def fetch_results_by_race(year: int, circuit_id: str) -> list[ResultData]:
-    race_data = _fetch_data(year, f"circuits/{circuit_id}/results/")
+    race_data = _fetch_data(year, "circuits", circuit_id, "results")
     if race_data is None:
         print(f"No result for circuit {circuit_id}")
         return []

--- a/src/f1_race_analytics/f1_data.py
+++ b/src/f1_race_analytics/f1_data.py
@@ -175,6 +175,16 @@ def _convert_to_dt(d: str) -> date:
     return datetime.strptime(d, "%Y-%m-%d").date()
 
 
+def _build_url(year: int, *segments: str) -> str:
+    """
+    Build a URL by joining path segments
+    """
+    base_path = f"{JOLPICA_ENDPOINT}/{year}"
+    endpoint = "/".join(segments)
+    url = f"{base_path}/{endpoint}/"
+    return url
+
+
 def _fetch_data(year: int, endpoint: str) -> dict[str, dict] | None:
     """
     Retrieve historical data from Jolpica F1 API:

--- a/src/f1_race_analytics/tests/test_f1_data.py
+++ b/src/f1_race_analytics/tests/test_f1_data.py
@@ -1,6 +1,11 @@
 import pytest
 
-from f1_race_analytics.f1_data import JOLPICA_ENDPOINT, _build_url
+from f1_race_analytics.f1_data import (
+    JOLPICA_ENDPOINT,
+    _build_url,
+    fetch_drivers_by_constructor,
+    fetch_results_by_race,
+)
 
 
 def test_build_url_exact_match():
@@ -20,3 +25,31 @@ def test_build_url_no_double_slashes(segments):
     url = _build_url(2026, *segments)
 
     assert "//" not in url.removeprefix("https://")
+
+
+def test_fetch_drivers_passes_clean_segments(monkeypatch):
+    calls = []
+
+    def fake_fetch(year, *segments):
+        calls.append((year, segments))
+        return None
+
+    monkeypatch.setattr("f1_race_analytics.f1_data._fetch_data", fake_fetch)
+
+    fetch_drivers_by_constructor(2026, "red_bull")
+
+    assert calls == [(2026, ("constructors", "red_bull", "drivers"))]
+
+
+def test_fetch_results_passes_clean_segments(monkeypatch):
+    calls = []
+
+    def fake_fetch(year, *segments):
+        calls.append((year, segments))
+        return None
+
+    monkeypatch.setattr("f1_race_analytics.f1_data._fetch_data", fake_fetch)
+
+    fetch_results_by_race(2026, "monza")
+
+    assert calls == [(2026, ("circuits", "monza", "results"))]

--- a/src/f1_race_analytics/tests/test_f1_data.py
+++ b/src/f1_race_analytics/tests/test_f1_data.py
@@ -1,0 +1,22 @@
+import pytest
+
+from f1_race_analytics.f1_data import JOLPICA_ENDPOINT, _build_url
+
+
+def test_build_url_exact_match():
+    url = _build_url(2026, "constructors", "red_bull", "drivers")
+
+    assert url == f"{JOLPICA_ENDPOINT}/2026/constructors/red_bull/drivers/"
+
+
+@pytest.mark.parametrize(
+    "segments",
+    [
+        ("races",),
+        ("constructors", "red_bull", "drivers"),
+    ],
+)
+def test_build_url_no_double_slashes(segments):
+    url = _build_url(2026, *segments)
+
+    assert "//" not in url.removeprefix("https://")


### PR DESCRIPTION
Routes all Jolpica URL building through a single `_build_url(year, *segments)` that owns every separator, and changes `_fetch_data` and its callers to pass discrete segments. This removes the `//` that two callers produced and makes a misplaced separator impossible to write.

Done in small steps: add `_build_url` with its test, route `_fetch_data` through it, switch the callers to discrete segments, and add tests covering the two callers.

Tests: `_build_url` has an exact-URL test and a parametrized no-`//` invariant. The two previously slash-laden callers now have tests asserting they pass clean segments, by mocking `_fetch_data`.

Scope: Jolpica only. Sportmonks stays a separate datasource.

Closes #83