### PR TITLE
refactor: single commit in create_championship (flush for IDs)

### DIFF
--- a/src/f1_race_analytics/database.py
+++ b/src/f1_race_analytics/database.py
@@ -145,7 +145,7 @@ def create_championship(
                 nationality=driver_data.nationality,
             )
             session.add(driver)
-        session.commit()
+        session.flush()
 
         if championship.id is None or constructor.id is None or driver.id is None:
             raise ValueError(
@@ -159,8 +159,8 @@ def create_championship(
         )
 
         session.add(link)
-        session.commit()
 
+    session.commit()
     session.refresh(championship)
 
     return championship

--- a/src/f1_race_analytics/tests/test_database.py
+++ b/src/f1_race_analytics/tests/test_database.py
@@ -233,6 +233,14 @@ def test_create_championship(session, constructor_driver_pairs):
     ]
 
 
+def test_create_championship_dedupes_shared_constructor(
+    session, constructor_driver_pairs
+):
+    create_championship(session, 2026, constructor_driver_pairs)
+    constructors = session.exec(select(Constructor)).all()
+    assert len(constructors) == 2
+
+
 def test_championship_entry_link(session):
     """
     Test the 3-way link table (ChampionshipEntryLink) that connects


### PR DESCRIPTION
**Problem**

`create_championship` commits twice inside its per-pair loop: once after adding the constructor and driver to populate their auto-increment IDs, and once after adding the `ChampionshipEntryLink`. For N pairs that is roughly 2N transactions.

Two costs follow. Each commit forces a durability sync, so the work scales as a sync per pair rather than one for the batch. And committing per pair makes the populate non-atomic: a failure partway through leaves some pairs permanently written and the rest missing.

**Fix**

Swap the first commit for `session.flush()`, which still assigns `constructor.id` and `driver.id` inside the open transaction, drop the second commit, and add a single `session.commit()` after the loop. `session.refresh(championship)` stays after that commit. One commit now seals the whole batch, so the populate is atomic and pays a single sync.

**Behaviour preserved**

- The `constructor.id is None` guard still holds, because flush assigns the key just as commit did.
- The look-up-or-create dedup still works, since a flushed row is visible to later iterations' queries within the same open transaction.
- The existing `test_database.py` suite stays green.
- Added `test_create_championship_dedupes_shared_constructor`, a focused check that two pairs sharing a constructor produce one `Constructor` row, not two.

**Out of scope**

`create_races` and `create_race_results` already commit once each and are untouched.

Closes #24