### PR TITLE
feat: support sprint points in standings

### DIFF
--- a/src/f1_race_analytics/app.py
+++ b/src/f1_race_analytics/app.py
@@ -26,6 +26,7 @@ from .database import (
 )
 from .f1_data import (
     EventStatus,
+    SessionType,
     fetch_constructor_driver_pairs,
     fetch_races,
     fetch_results_by_race,
@@ -48,7 +49,9 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             if race.status() == EventStatus.PAST:
                 result_data = fetch_results_by_race(YEAR, race.circuit_id)
                 if result_data:
-                    create_race_results(session, YEAR, result_data)
+                    create_race_results(
+                        session, YEAR, SessionType.GRAND_PRIX, result_data
+                    )
     yield
 
 

--- a/src/f1_race_analytics/database.py
+++ b/src/f1_race_analytics/database.py
@@ -167,7 +167,10 @@ def create_championship(
 
 
 def create_race_results(
-    session: Session, year: int, race_result_data: list[ResultData]
+    session: Session,
+    year: int,
+    session_type: SessionType,
+    race_result_data: list[ResultData],
 ) -> list[RaceResult] | None:
     """
     Create the RaceResult table, linking results to races for a given year
@@ -199,7 +202,7 @@ def create_race_results(
         result = RaceResult(
             race_id=race.id,
             driver_id=driver.id,
-            session_type=SessionType.GRAND_PRIX,
+            session_type=session_type,
             position=position,
             points=points,
         )

--- a/src/f1_race_analytics/database.py
+++ b/src/f1_race_analytics/database.py
@@ -5,7 +5,7 @@ from typing import NamedTuple
 from sqlalchemy.orm import selectinload
 from sqlmodel import Session, SQLModel, create_engine, select
 
-from .f1_data import ConstructorData, DriverData, Event, ResultData
+from .f1_data import ConstructorData, DriverData, Event, ResultData, SessionType
 from .models import (
     Championship,
     ChampionshipEntryLink,
@@ -199,6 +199,7 @@ def create_race_results(
         result = RaceResult(
             race_id=race.id,
             driver_id=driver.id,
+            session_type=SessionType.GRAND_PRIX,
             position=position,
             points=points,
         )

--- a/src/f1_race_analytics/f1_data.py
+++ b/src/f1_race_analytics/f1_data.py
@@ -176,6 +176,28 @@ def fetch_results_by_race(year: int, circuit_id: str) -> list[ResultData]:
     return result_info
 
 
+def fetch_sprint_results_by_race(year: int, circuit_id: str) -> list[ResultData]:
+    sprint_data = _fetch_data(year, "circuits", circuit_id, "sprint")
+    if sprint_data is None:
+        print(f"No result for sprint for circuit {circuit_id}")
+        return []
+    sprint_races = sprint_data.get("MRData", {}).get("RaceTable", {}).get("Races", [])
+    if not sprint_races:
+        print(f"No sprint races found for circuit {circuit_id}")
+        return []
+    results = sprint_races[0].get("SprintResults", [])
+    result_info = [
+        ResultData(
+            circuit_id,
+            result.get("Driver", {}).get("driverId", ""),
+            result.get("position", ""),
+            result.get("points", ""),
+        )
+        for result in results
+    ]
+    return result_info
+
+
 def _convert_to_dt(d: str) -> date:
     return datetime.strptime(d, "%Y-%m-%d").date()
 

--- a/src/f1_race_analytics/f1_data.py
+++ b/src/f1_race_analytics/f1_data.py
@@ -1,5 +1,5 @@
 from datetime import date, datetime
-from enum import Enum
+from enum import Enum, StrEnum, auto
 from typing import NamedTuple
 
 import httpx
@@ -11,6 +11,11 @@ class EventStatus(Enum):
     FUTURE = "future"
     LIVE = "live"
     PAST = "past"
+
+
+class SessionType(StrEnum):
+    GRAND_PRIX = auto()
+    SPRINT = auto()
 
 
 def compute_status(start_date: date, end_date: date) -> EventStatus:

--- a/src/f1_race_analytics/models.py
+++ b/src/f1_race_analytics/models.py
@@ -2,7 +2,7 @@ from datetime import date
 
 from sqlmodel import Field, Relationship, SQLModel
 
-from .f1_data import EventStatus, compute_status
+from .f1_data import EventStatus, SessionType, compute_status
 
 
 class Championship(SQLModel, table=True):
@@ -87,6 +87,7 @@ class RaceResult(SQLModel, table=True):
     driver_id: int | None = Field(
         default=None, foreign_key="driver.id", primary_key=True
     )
+    session_type: SessionType = Field(primary_key=True)
 
     # Relationship context: data that belongs to the combination Race-Driver
     position: int

--- a/src/f1_race_analytics/tests/conftest.py
+++ b/src/f1_race_analytics/tests/conftest.py
@@ -10,7 +10,13 @@ from f1_race_analytics.database import (
     create_race_results,
     create_races,
 )
-from f1_race_analytics.f1_data import ConstructorData, DriverData, Event, ResultData
+from f1_race_analytics.f1_data import (
+    ConstructorData,
+    DriverData,
+    Event,
+    ResultData,
+    SessionType,
+)
 
 
 @pytest.fixture
@@ -131,6 +137,7 @@ def seeded_season(session, race_events, standings_pairs, monkeypatch):
     create_race_results(
         session,
         year,
+        SessionType.GRAND_PRIX,
         [
             ResultData("albert_park", "russell", "1", "25"),
             ResultData("albert_park", "antonelli", "2", "18"),
@@ -141,6 +148,7 @@ def seeded_season(session, race_events, standings_pairs, monkeypatch):
     create_race_results(
         session,
         year,
+        SessionType.GRAND_PRIX,
         [
             ResultData("suzuka", "antonelli", "1", "25"),
             ResultData("suzuka", "leclerc", "3", "15"),

--- a/src/f1_race_analytics/tests/test_database.py
+++ b/src/f1_race_analytics/tests/test_database.py
@@ -10,7 +10,12 @@ from f1_race_analytics.database import (
     get_constructor_ranks,
     get_driver_ranks,
 )
-from f1_race_analytics.f1_data import ConstructorData, DriverData, ResultData
+from f1_race_analytics.f1_data import (
+    ConstructorData,
+    DriverData,
+    ResultData,
+    SessionType,
+)
 from f1_race_analytics.models import (
     Championship,
     ChampionshipEntryLink,
@@ -100,8 +105,8 @@ def seeded_standings(session, race_events, standings_pairs):
     ]
     create_races(session, 2026, race_events)
     create_championship(session, 2026, standings_pairs)
-    create_race_results(session, 2026, australian_results)
-    create_race_results(session, 2026, japanese_results)
+    create_race_results(session, 2026, SessionType.GRAND_PRIX, australian_results)
+    create_race_results(session, 2026, SessionType.GRAND_PRIX, japanese_results)
 
 
 def test_create_races(session, race_events):

--- a/src/f1_race_analytics/tests/test_database.py
+++ b/src/f1_race_analytics/tests/test_database.py
@@ -350,3 +350,44 @@ def test_get_driver_ranks(session, seeded_standings):
         ("Leclerc", 30),
         ("Hamilton", 20),
     ]
+
+
+def test_sprint_points_count_toward_driver_standings(
+    session, race_events, standings_pairs
+):
+    create_races(session, 2026, race_events)
+    create_championship(session, 2026, standings_pairs)
+
+    create_race_results(
+        session,
+        2026,
+        SessionType.GRAND_PRIX,
+        [
+            ResultData(
+                circuit_id="shanghai", driver_id="hamilton", position="3", points="15"
+            ),
+            ResultData(
+                circuit_id="shanghai", driver_id="leclerc", position="4", points="12"
+            ),
+        ],
+    )
+    create_race_results(
+        session,
+        2026,
+        SessionType.SPRINT,
+        [
+            ResultData(
+                circuit_id="shanghai", driver_id="leclerc", position="2", points="7"
+            ),
+            ResultData(
+                circuit_id="shanghai", driver_id="hamilton", position="3", points="6"
+            ),
+        ],
+    )
+
+    standings = get_driver_ranks(session, 2026)
+
+    assert [(s.driver.last_name, s.points) for s in standings] == [
+        ("Hamilton", 21),
+        ("Leclerc", 19),
+    ]

--- a/src/f1_race_analytics/tests/test_f1_data.py
+++ b/src/f1_race_analytics/tests/test_f1_data.py
@@ -2,9 +2,11 @@ import pytest
 
 from f1_race_analytics.f1_data import (
     JOLPICA_ENDPOINT,
+    ResultData,
     _build_url,
     fetch_drivers_by_constructor,
     fetch_results_by_race,
+    fetch_sprint_results_by_race,
 )
 
 
@@ -53,3 +55,67 @@ def test_fetch_results_passes_clean_segments(monkeypatch):
     fetch_results_by_race(2026, "monza")
 
     assert calls == [(2026, ("circuits", "monza", "results"))]
+
+
+def test_fetch_sprints_passes_clean_segments(monkeypatch):
+    calls = []
+
+    def fake_fetch(year, *segments):
+        calls.append((year, segments))
+        return None
+
+    monkeypatch.setattr("f1_race_analytics.f1_data._fetch_data", fake_fetch)
+
+    fetch_sprint_results_by_race(2026, "shanghai")
+
+    assert calls == [(2026, ("circuits", "shanghai", "sprint"))]
+
+
+def test_fetch_sprint_results(monkeypatch):
+    calls = []
+
+    def fake_fetch(year, *segments):
+        calls.append((year, segments))
+        return {
+            "MRData": {
+                "RaceTable": {
+                    "Races": [
+                        {
+                            "SprintResults": [
+                                {
+                                    "Driver": {"driverId": "russell"},
+                                    "position": "1",
+                                    "points": "8",
+                                },
+                                {
+                                    "Driver": {"driverId": "leclerc"},
+                                    "position": "2",
+                                    "points": "7",
+                                },
+                                {
+                                    "Driver": {"driverId": "hamilton"},
+                                    "position": "3",
+                                    "points": "6",
+                                },
+                            ]
+                        }
+                    ]
+                }
+            }
+        }
+
+    monkeypatch.setattr("f1_race_analytics.f1_data._fetch_data", fake_fetch)
+
+    sprint_results = fetch_sprint_results_by_race(2026, "shanghai")
+
+    assert sprint_results == [
+        ResultData(
+            circuit_id="shanghai", driver_id="russell", position="1", points="8"
+        ),
+        ResultData(
+            circuit_id="shanghai", driver_id="leclerc", position="2", points="7"
+        ),
+        ResultData(
+            circuit_id="shanghai", driver_id="hamilton", position="3", points="6"
+        ),
+    ]


### PR DESCRIPTION
**Problem**

Driver and constructor standings were short by sprint points (#85). The rank functions sum `RaceResult.points`, but `RaceResult` could hold only one row per `(race, driver)`, and only Grand Prix results were ever fetched, so sprint points had nowhere to live and were never counted.

**Change**

Give a result a session dimension so a sprint and a Grand Prix result can coexist for the same driver at the same weekend, and feed sprint data through the existing path:

- `RaceResult`'s primary key gains `session_type`, a new `SessionType` string enum with `GRAND_PRIX` and `SPRINT`, so the key is now `(race_id, driver_id, session_type)`. Existing rows are written as `GRAND_PRIX`.
- `fetch_sprint_results_by_race` mirrors the Grand Prix fetch against the `sprint` endpoint and returns the same `ResultData`.
- `create_race_results` takes a `session_type` and stamps it on each row. Callers pass it explicitly, with no default, so a missing one fails loudly instead of mislabelling a sprint as a Grand Prix.
- The rank functions already sum every `RaceResult` for a race, so once sprint rows exist they fold in with no change to the standings code.

**Tested**

- A parsing test for `fetch_sprint_results_by_race`: a mocked `_fetch_data` returns a sprint payload, and the test asserts `SprintResults` maps to the right `ResultData`.
- A standings test that seeds a Grand Prix and a sprint result for the same driver at one weekend and asserts the driver's total is the sum of both.
- The existing suite stays green; the `create_race_results` change is behaviour-preserving, since every current caller still writes Grand Prix rows.

**Not in this PR**

The live populate still fetches only Grand Prix results, so deployed standings will not change yet. Wiring `fetch_sprint_results_by_race` into the populate belongs with the paced populate script (#22), to avoid adding sprint requests to the unthrottled startup burst that is already hitting Jolpica's rate limit. This delivers and proves the mechanism but does not close #85.

Refs #85